### PR TITLE
Add Voting TAC members as CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+CODEOWNERS @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou 
+MAINTAINERS.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
+Caliptra_WG_Technical_Charter.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
+LICENSE @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou

--- a/Caliptra_WG_Technical_Charter.md
+++ b/Caliptra_WG_Technical_Charter.md
@@ -130,7 +130,8 @@ with an alternative employee representative at any time.
 The TAC members will be listed by name, with pseudonym or GitHub username listed
 optionally, in the [MAINTAINERS](MAINTAINERS.md) document within the Workgroup
 open source repository. Membership changes are reflected by pull requests
-against the TAC membership list document.
+against the TAC membership list document and relevant CODEOWNERS files
+([example](CODEOWNERS)).
 
 ### TAC Chair
 


### PR DESCRIPTION
Protect relevant TAC files with the current TAC ownership

spec and README remain without explicit CODEOWNERs