### PR TITLE
Switch number of required approvals for software commits from 2 to 1.

### DIFF
--- a/github_rules.md
+++ b/github_rules.md
@@ -5,7 +5,7 @@ github configuration.
 
 * Require a pull request before merging
 * Require approvals
-* Required number of approvals: 2
+* Required number of approvals: 2 for spec, 1 for code
 * Dismiss stale pull request approvals when new commits are pushed
 * Require review from code owners
 * Require approval of most recent reviewable push (whether the most recent reviewable push must be approved by someone other than the person who pushed it)

--- a/github_rules.md
+++ b/github_rules.md
@@ -5,7 +5,7 @@ github configuration.
 
 * Require a pull request before merging
 * Require approvals
-* Required number of approvals: 2 for spec, 1 for code
+* Required number of approvals: 2 for spec and RTL, 1 for software
 * Dismiss stale pull request approvals when new commits are pushed
 * Require review from code owners
 * Require approval of most recent reviewable push (whether the most recent reviewable push must be approved by someone other than the person who pushed it)


### PR DESCRIPTION
2 approvals is turning out to be too onerous for timely firmware development.