### PR TITLE
Remove "Require approval of the most recent reviewable push"

### DIFF
--- a/github_rules.md
+++ b/github_rules.md
@@ -8,7 +8,6 @@ github configuration.
 * Required number of approvals: 2 for spec and RTL, 1 for software
 * Dismiss stale pull request approvals when new commits are pushed
 * Require review from code owners
-* Require approval of most recent reviewable push (whether the most recent reviewable push must be approved by someone other than the person who pushed it)
 * Require conversation resolution before merging
 * Restrict who can dismiss pull request reviews
 * Do not allow bypassing the above settings


### PR DESCRIPTION
This is causing significant friction when the PR becomes stale because somebody else pushed to main. Consider this common workflow:

  * Person A is working on PR3, sends out for review
  * Person X approves PR3
  * Person B merges PR4
  * Person A can't merge into main because "This branch is out-of-date with the base branch"
  * Person A hits the "merge from main" button
  * Person A can't submit without a fresh approval from Person X. Error: "New changes require approval from someone other than you because you were the last pusher"
  * Person X is out for the day, and Person A gets really angry