### PR TITLE
Allow caliptra-rtl merge commits / non-linear history

### DIFF
--- a/GitHubRules.md
+++ b/GitHubRules.md
@@ -13,7 +13,12 @@ GitHub configuration.
 * Do not allow bypassing the above settings
 * Restrict who can push to matching branches: only relevant folks in
   [MAINTAINERS](MAINTAINERS.md) for `main` and `release/*` branches
-* Require linear history
+* For caliptra-rtl Repository
+  * Don't require non-linear history
+  * Allow "merge commits"
+* For other Repositories
+  * Require linear history
+  * Disallow "merge commits"
 
 Will not set
 * Allow force pushes


### PR DESCRIPTION
This is necessary to support retaining full commit history (and bidirectional merges) between the dev-msft and dev-google, and main branches.