### PR TITLE
Update HW ERROR reporting and handling section

### DIFF
--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -1377,9 +1377,9 @@ This section describes Caliptra error reporting and handling.
 - Fatal errors will log the FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_fatal wire.
-	- SOCs must connect this into their SOC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SOC shall treat any outstanding commands with Caliptra as failed, and perform a core reset using the signal `cptra_rst_b`. If Caliptra is instantiated in the Security Subsystem configuration, the whole subsystem should be reset.
+	- SOCs must connect this into their SOC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SOC shall treat any outstanding commands with Caliptra as failed, and perform a reset using the signal `cptra_rst_b`.
     - Error Mask registers (writable only by Caliptra uC) may be used to prevent error signal assertion per-event. Mask registers only impact interrupts when set prior to the error occurrence.
-    - cptra\_error\_fatal will remain asserted until Caliptra Core is reset. Note that, although the HW FATAL ERROR register fields may be cleared at any time, a reset is still required to clear the interrupt.
+    - cptra\_error\_fatal will remain asserted until Caliptra is reset. Note that, although the HW FATAL ERROR register fields may be cleared at any time, a reset is still required to clear the interrupt.
 - When a fatal error occurs, all assets (UDS fuses, DEOBF\_KEK, Key Slots etc.) are cleared. Please note that UDS\_FUSE, DEOBF\_KEK may have already been cleared depending on when the fatal error happened.
 
 **Non-Fatal errors**
@@ -1387,7 +1387,7 @@ This section describes Caliptra error reporting and handling.
 - Non-Fatal errors will log the NON-FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_non\_fatal wire.
-- Caliptra Core reset via `cptra_rst_b` or a write to clear the NON-FATAL ERROR register will cause the interrupt to deassert.
+- Caliptra reset via `cptra_rst_b` or a write to clear the NON-FATAL ERROR register will cause the interrupt to deassert.
 - Optional for SOCs to include this signal in their logic.
 
 **FW Errors**

--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -1377,7 +1377,7 @@ This section describes Caliptra error reporting and handling.
 - Fatal errors will log the FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_fatal wire.
-    - SoCs must connect this into their SoC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SoC shall treat any outstanding commands with Caliptra as failed, and SoC may recover by performing a Caliptra reset using the signal `cptra_rst_b`.
+    - SoCs should connect this into their SoC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SoC shall treat any outstanding commands with Caliptra as failed, and SoC may recover by performing a Caliptra reset using the signal `cptra_rst_b`.
     - This signal is used to prevent forward progress of the boot process if measurement submission to Caliptra fails. If SoC detects a Caliptra fatal error while the SoC is in steady state, then there is no obligation for the SoC to immediately address that error. If rebooting the SoC for such failures is deemed unacceptable to uptime, the SoC should implement the ability to trigger a Caliptra Warm Reset independently of the SoC, and may use this mechanism to recover.
     - Error Mask registers (writable only by Caliptra uC) may be used to prevent error signal assertion per-event. Mask registers only impact interrupts when set prior to the error occurrence.
     - cptra\_error\_fatal will remain asserted until Caliptra is reset. Note that, although the HW FATAL ERROR register fields may be cleared at any time, a reset is still required to clear the interrupt.

--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -1377,8 +1377,8 @@ This section describes Caliptra error reporting and handling.
 - Fatal errors will log the FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_fatal wire.
-    - SOCs must connect this into their SOC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SOC shall treat any outstanding commands with Caliptra as failed, and SOC may recover by performing a Caliptra reset using the signal `cptra_rst_b`.
-    - This signal is used to prevent forward progress of the boot process if measurement submission to Caliptra fails. If SOC detects a Caliptra fatal error while the SoC is in steady state, then there is no obligation for the SoC to immediately address that error. If rebooting the SoC for such failures is deemed unacceptable to uptime, the SoC should implement the ability to trigger a Caliptra Warm Reset independently of the SoC, and may use this mechanism to recover.
+    - SoCs must connect this into their SoC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SoC shall treat any outstanding commands with Caliptra as failed, and SoC may recover by performing a Caliptra reset using the signal `cptra_rst_b`.
+    - This signal is used to prevent forward progress of the boot process if measurement submission to Caliptra fails. If SoC detects a Caliptra fatal error while the SoC is in steady state, then there is no obligation for the SoC to immediately address that error. If rebooting the SoC for such failures is deemed unacceptable to uptime, the SoC should implement the ability to trigger a Caliptra Warm Reset independently of the SoC, and may use this mechanism to recover.
     - Error Mask registers (writable only by Caliptra uC) may be used to prevent error signal assertion per-event. Mask registers only impact interrupts when set prior to the error occurrence.
     - cptra\_error\_fatal will remain asserted until Caliptra is reset. Note that, although the HW FATAL ERROR register fields may be cleared at any time, a reset is still required to clear the interrupt.
 - When a fatal error occurs, all assets (UDS fuses, DEOBF\_KEK, Key Slots etc.) are cleared. Please note that UDS\_FUSE, DEOBF\_KEK may have already been cleared depending on when the fatal error happened.
@@ -1389,7 +1389,7 @@ This section describes Caliptra error reporting and handling.
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_non\_fatal wire.
 - Caliptra reset via `cptra_rst_b` or a write to clear the NON-FATAL ERROR register will cause the interrupt to deassert.
-- Optional for SOCs to include this signal in their logic.
+- Optional for SoCs to include this signal in their logic.
 
 **FW Errors**
 

--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -1377,7 +1377,8 @@ This section describes Caliptra error reporting and handling.
 - Fatal errors will log the FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_fatal wire.
-	- SOCs must connect this into their SOC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SOC shall treat any outstanding commands with Caliptra as failed, and perform a reset using the signal `cptra_rst_b`.
+    - SOCs must connect this into their SOC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SOC shall treat any outstanding commands with Caliptra as failed, and SOC may recover by performing a Caliptra reset using the signal `cptra_rst_b`.
+    - This signal is used to prevent forward progress of the boot process if measurement submission to Caliptra fails. If SOC detects a Caliptra fatal error while the SoC is in steady state, then there is no obligation for the SoC to immediately address that error. If rebooting the SoC for such failures is deemed unacceptable to uptime, the SoC should implement the ability to trigger a Caliptra Warm Reset independently of the SoC, and may use this mechanism to recover.
     - Error Mask registers (writable only by Caliptra uC) may be used to prevent error signal assertion per-event. Mask registers only impact interrupts when set prior to the error occurrence.
     - cptra\_error\_fatal will remain asserted until Caliptra is reset. Note that, although the HW FATAL ERROR register fields may be cleared at any time, a reset is still required to clear the interrupt.
 - When a fatal error occurs, all assets (UDS fuses, DEOBF\_KEK, Key Slots etc.) are cleared. Please note that UDS\_FUSE, DEOBF\_KEK may have already been cleared depending on when the fatal error happened.

--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -1377,17 +1377,17 @@ This section describes Caliptra error reporting and handling.
 - Fatal errors will log the FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_fatal wire.
-	- SOCs must hook this into their SOC error handling logic.
+	- SOCs must connect this into their SOC error handling logic. Upon detection of a FATAL ERROR in Caliptra, SOC shall treat any outstanding commands with Caliptra as failed, and perform a core reset using the signal `cptra_rst_b`. If Caliptra is instantiated in the Security Subsystem configuration, the whole subsystem should be reset.
     - Error Mask registers (writable only by Caliptra uC) may be used to prevent error signal assertion per-event. Mask registers only impact interrupts when set prior to the error occurrence.
-    - cptra\_error\_fatal will remain asserted until Caliptra system is reset. Note that, although the HW FATAL ERROR register may be cleared at any time, a reset is still required to clear the interrupt.
-- When a fatal error occurs, all assets (UDS fuses, DEOBF\_KEK, Key Slots etc.)  are cleared. Please note that UDS\_FUSE, DEOBF\_KEK may have already been cleared depending on when the fatal error happened.
+    - cptra\_error\_fatal will remain asserted until Caliptra Core is reset. Note that, although the HW FATAL ERROR register fields may be cleared at any time, a reset is still required to clear the interrupt.
+- When a fatal error occurs, all assets (UDS fuses, DEOBF\_KEK, Key Slots etc.) are cleared. Please note that UDS\_FUSE, DEOBF\_KEK may have already been cleared depending on when the fatal error happened.
 
 **Non-Fatal errors**
 
 - Non-Fatal errors will log the NON-FATAL ERROR reasons into an arch register that is RW from the external world. This register must be sticky (as in reset is on powergood).
 - This register may be cleared at any time via register write (W1C).
 - Caliptra will signal this using a cptra\_error\_non\_fatal wire.
-- System reset or a write to clear the NON-FATAL ERROR register will cause the interrupt to deassert.
+- Caliptra Core reset via `cptra_rst_b` or a write to clear the NON-FATAL ERROR register will cause the interrupt to deassert.
 - Optional for SOCs to include this signal in their logic.
 
 **FW Errors**


### PR DESCRIPTION
Remove several HW Non-Fatal error conditions and move to other regions:
 - AHB decode triggers an NMI, so is moved to FW FATAL ERROR register. 
 - Invalid Key Slot (by FW) is removed as this should be reported as a FW error
 - Crypto processing errors are moved to FW non-fatal, as the final status is detected by FW and can reliably be reported even if an error occurs (as Crypto errors will not cause a system failure).

Add description for interrupt pin behavior for FATAL/NON-FATAL registers