### PR TITLE
Change GitHub settings to allow "Auto-merge".

### DIFF
--- a/GitHubRules.md
+++ b/GitHubRules.md
@@ -7,6 +7,7 @@ GitHub configuration.
 * Require approvals
 * Required number of approvals: 2 for spec and RTL, 1 for software
 * Dismiss stale pull request approvals when new commits are pushed
+* Allow auto-merge
 * Require review from code owners
 * Require conversation resolution before merging
 * Restrict who can dismiss pull request reviews


### PR DESCRIPTION
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request

This workflow is pretty common:
1. Go to merge someone's PR, then notice that it's stale (some other PR has been merged since it was last touched)
2. I hit the "update from main" button, and a new CI run is launched
3. I go work on something else while the CI is running, and forget about the PR
4. Somebody reminds me about the PR, and 30% of the time it's stale and I need to go back to step 2
(edited)