### PR TITLE
Make GHA fork PR workflow settings stricter.

### DIFF
--- a/GitHubRules.md
+++ b/GitHubRules.md
@@ -20,6 +20,8 @@ GitHub configuration.
 * For other Repositories
   * Require linear history
   * Disallow "merge commits"
+* Set "Actions" / "General" / "Fork pull request workflows from
+  outside collborators" to "Require approval for all outside collaborators"
 
 Will not set
 * Allow force pushes


### PR DESCRIPTION
Switch the "Actions" / "General" / "Fork pull request workflows from outside collborators" setting from "Require approval for first-time contributors" to "Require approval for all outside collaborators". This makes it much harder for a drive-by "typo fixer" contributor to execute arbitrary code in our GitHub Actions runners.