### PR TITLE
update Caliptra.md

### DIFF
--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -667,7 +667,7 @@ Caliptra RT generates the DPE certificate and endorses it with the Alias<sub>RT<
 * End-of-life state is owned by SoC. In end-of-life device lifecycle state, Caliptra shall not not be brought out of reset.
 * Other encodings are reserved and always assumed to be in a secure state.
 
-Each of these security states may be mapped to different SoC level debug and security states. SoC’s requirement is that if the SoC enters a debug state, then Caliptra must also be in an unsecured state where all assets are cleared. Caliptra security state is captured by hardware on every warm reset; therefore SoC integrators enforce the security state transition policies for cold boot events. These policies are described in the preceding table.
+Each of these security states may be mapped to different SoC level debug and security states. SoC’s requirement is that if the SoC enters an insecure state, then Caliptra must also be in an insecure state where all assets are cleared. Caliptra security state is captured by hardware on every warm reset; therefore SoC integrators enforce the security state transition policies for cold boot events. These policies are described in the preceding table.
 
 ## Service surface
 

--- a/doc/caliptra_1x/Caliptra.md
+++ b/doc/caliptra_1x/Caliptra.md
@@ -617,7 +617,7 @@ Caliptra RT generates the DPE certificate and endorses it with the Alias<sub>RT<
 * End-of-life state is owned by SoC. In end-of-life device lifecycle state, Caliptra shall not not be brought out of reset.
 * Other encodings are reserved and always assumed to be in a secure state.
 
-Each of these security states may be mapped to different SoC level debug and security states. SoC’s requirement is that if the SoC enters a debug state, then Caliptra must also be in an unsecured state where all assets are cleared. Caliptra security state is captured by hardware on every warm reset; therefore SoC integrators enforce the security state transition policies for cold boot events. These policies are described in the preceding table.
+Each of these security states may be mapped to different SoC level debug and security states. SoC’s requirement is that if the SoC enters an insecure state, then Caliptra must also be in an insecure state where all assets are cleared. Caliptra security state is captured by hardware on every warm reset; therefore SoC integrators enforce the security state transition policies for cold boot events. These policies are described in the preceding table.
 
 ## Service surface
 


### PR DESCRIPTION
- Changing SoC 'debug state' to 'insecure state'
  I'm not entirely sure if Caliptra and the SoC really need to be synchronized regarding the debug state across all lifecycle stages. For example, if we're in a product manufacturing stage and if there is an environment that ensures secure manufacturing (though defining this itself is also challenging), wouldn't it still be possible to consider the SoC to be in a secure state even if it's in a debug state (e.g., JTAG opened)? Additionally, during manufacturing, the SoC state could transition from debug state to non-debug state. However, should the state of Caliptra and the SoC be synchronized at every moment throughout this process? I feel 'insecure state' might be more appropriate than 'debug state.' Is there a specific reason why it must be the debug state? I'd like to hear your thoughts on this.

- Changing Caliptra 'unsecured state' to 'insecure state'
  In the Caliptra.md, states are defined as Secure/Insecure. Except for this one statement, the term 'insecure' is used consistently throughout

#252

