### PR TITLE
Update Caliptra SS streaming boot specification

### DIFF
--- a/doc/Caliptra.md
+++ b/doc/Caliptra.md
@@ -1498,30 +1498,76 @@ Please refer to Caliptra subsystem Hardware specification.
 
 # Caliptra Subsystem Streaming Boot Sequence
 
-1. **Initialization step:** Caliptra ROM initializes PROT_CAP, DEVICE_ID, DEVICE_STATUS, RECOVERY_STATUS, HW_STATUS, INDIRECT_FIFO_STATUS (remove these two reg from ROM initialization) default values. Note: Any I3C initialization is done b/w MCU ROM, I3C target HW and I3C initiator. This is not part of this document.
-2. MCU Specific SoC init of I3C & streaming boot interface.
-    1. MCU ROM can set HW_STATUS register per recovery spec, at any time based on SOC specific conditions.
-    2. MCU ROM will program DEVICE_ID register value based on associated fuse values.
-    3. I3C device must update FIFO size (1-256 Byte), Max transfer size and type of region (tie this to 0x1) to INDIRECT_FIFO_STATUS register, which could be read by BMC firmware to understand the size of the FIFO & max transfer size.
-3. Caliptra ROM will update PROT_CAP register, bit 11 to set to ‘1 “Flashless boot (From RESET)”. Caliptra ROM will set other register bits based on other recovery capabilities. PROT_CAP will also indicate support for FIFO CMS for I3C device by updating byte 10-11, bit 12 with 0x1 “FIFO CMS Support”.
-4. To start streaming boot, Caliptra ROM will write DEVICE_STATUS register to “RECOVERY_MODE” by writing byte 0, with data 0x3. Caliptra ROM will write DEVICE_STATUS register’s byte 2-3 to set the FSB parameter (0x12).
-5. I3C streaming boot HW will set byte 1 based on the DEVICE_STATUS register based on the rules defined for this register. This register status will assist BMC operation.
-6. Caliptra ROM will write via DMA assist to RECOVERY_STATUS register with data of (byte 0, 0x1) and sets the streaming boot image index to 0x0
-7. BMC or a similar platform component will update INDIRECT_FIFO_CTRL with Component Memory Space (CMS) byte 0 with 0x0, Reset field byte 1 with 0x1 and Image size byte 2 to 5 field to size of the image.
-8. BMC or a similar platform component writes to INDIRECT_FIFO_DATA register. I3C device shall return a NACK response for any transfer that would cause the Head Pointer to advance to equal the Tail Pointer. BMC can implement flow control through NACK responses or by monitoring the FIFO space remaining via the Head and Tail Pointers.
-9. The I3C device will keep head and tail pointers along with FIFO status up to date into INDIRECT_FIFO_STATUS register. I3C streaming boot interface HW wait for an update to INDIRECT_DATA_REG with 1-256B data from BMC.
-10. If there is a write to INDIRECT_DATA_FIFO, I3C device will indicate data availability via side channel implemented as wire “payload_available” ( for more details read here) to Caliptra. Caliptra HW will latch this wire into the register for Caliptra firmware to read.
-11. Caliptra ROM arms DMA interface to read INDIRECT_FIFO_CTRL for the image size and programs DMA engine back to read the image data from INDIRECT_FIFO_DATA.
-12. Steps 9 through 11 repeat until all the images are pushed over I3C and it matches the image size initialized into the INDIRECT_FIFO_CTRL register.
-13. After the above steps, Caliptra ROM Firmware will wait for BMC to activate image indicated to Caliptra via side channel.
-14. If the Image is activated, update RECOVERY STATUS to “Booting recovery image” by writing byte0, with data 0x2. If the image is authenticated, then the Caliptra RT FW will update the image index in RECOVERY_STATUS register (0x1 in byte 0, bits 7:4) and then set then update the byte 0, bit 3:0 to “Awaiting for recovery image” (0x1)
-15. BMC or a similar platform component will send the next image as requested in the image index, and Caliptra RT FW and I3C HW go through the same flow as above.
+1. MCU ROM / MCU firmware / SOC initializes `PROT_CAP` and `DEVICE_STATUS`. Any I3C initialization required is performed by MCU ROM, I3C target HW, and I3C initiator. Populating `DEVICE_ID` & `HW_STATUS` will be part of integrators or vendors’ responsibilities. It is not a part of the streaming boot specification document. However, it is required before starting the streaming boot.
+2. Caliptra ROM/Firmware must update `PROT_CAP` register, bit 11 to set to ‘1 “Flashless boot (From RESET)”. `PROT_CAP` must indicate support for FIFO CMS for I3C device by updating byte 10-11, bit 12 with 0x1 “FIFO CMS Support”. Caliptra ROM/Firmware must update bit 7 push c-image support.
+3. To start streaming boot, Caliptra ROM will write `DEVICE_STATUS` register to “RECOVERY_MODE” by writing byte 0, with data 0x3. Caliptra ROM will write `DEVICE_STATUS` register’s byte 2-3 to set the FSB parameter (0x12).
+4. Caliptra ROM will write via DMA assist to `RECOVERY_STATUS` register with data of (byte 0, 0x1) and sets the streaming boot image index to 0x0.
+5. BMC or a similar platform component will update `INDIRECT_FIFO_CTRL` with Component Memory Space (CMS) byte 0 with 0x0, Reset field byte 1 with 0x1 and Image size byte 2 to 5 field to size of the image. Caliptra ROM/firmware will read `INDIRECT_FIFO_CTRL_IMG_SIZE` register for the image size.
+6. BMC or a similar platform component writes to `INDIRECT_FIFO_DATA` register. I3C device shall return a NACK response for any transfer that would cause the Head Pointer to advance to equal the Tail Pointer. BMC can implement flow control through NACK responses or by monitoring the FIFO space remaining via the Head and Tail Pointers.
+7. The I3C device will keep head and tail pointers along with FIFO status up to date into `INDIRECT_FIFO_STATUS` register. I3C streaming boot interface HW waits for an update to `INDIRECT_DATA_REG` with 1-256B data from BMC.
+8. If there is a write to `INDIRECT_DATA_FIFO`, I3C device will indicate data availability via side channel implemented as wire `payload_available` (for more details read here) to Caliptra. Caliptra HW will latch this wire into the register for Caliptra firmware to read.
+9. Caliptra ROM arms DMA interface to read `INDIRECT_FIFO_CTRL` for the image size and programs DMA engine back to read the image data from `INDIRECT_FIFO_DATA`.
+10. Steps 9 through 11 repeat until all the images are pushed over I3C and it matches the image size initialized into the `INDIRECT_FIFO_CTRL` register.
+11. After the above steps, Caliptra ROM Firmware will wait for BMC to activate the image indicated to Caliptra via side channel or Caliptra ROM could repetitively read `RECOVERY_CTRL` register byte 2 for value 0xf for image activation.
+12. If the Image is activated, update `RECOVERY_STATUS` to “Booting recovery image” by writing byte 0, with data 0x2.
+13. Irrespective of success or failure from image authentication (step 17 or 18), Caliptra ROM will clear the image activation bit before updating `RECOVERY_STATUS` register.
+14. If the image activation is successful, and another recovery image stage is expected, then the device shall increment the “Recovery image index” in `RECOVERY_STATUS` register (0x1 in byte 0, bits 7:4) and set the `RECOVERY_STATUS` byte 0, bit 3:0 to “Awaiting for recovery image” (0x1). If no other stages are expected, then the device shall set the `RECOVERY_STATUS` to “Recovery successful”. Also, Caliptra ROM/Caliptra RT must update the `DEVICE_STATUS` register to byte 0 with 0x5 to indicate Running Recovery Image.
+15. If the image consumption fails for any reason (for example, image authentication failure), Caliptra ROM/firmware will write `RECOVERY_STATUS` register with any of the following values to indicate recovery status:
+   - 0x0: Not in recovery mode
+   - 0x1: Awaiting recovery image
+   - 0x2: Booting recovery image
+   - 0x3: Recovery successful
+   - 0xc: Recovery failed
+   - 0xd: Recovery image authentication error
+   - 0xe: Error entering Recovery mode (might be administratively disabled)
+   - 0xf: Invalid component address space
+16. If the image consumption fails for any reason (for example, image authentication failure), Caliptra ROM/firmware must update `DEVICE_STATUS` to 0xE: Boot Failure (Recover Reason Code populated) & populate, Byte 2-3 with one of the Recovery Reason Codes from Recovery Reason Codes in OCP recovery Spec.
+17. BMC or a similar platform component will send the next image as requested in the image index, and Caliptra RT FW and I3C HW go through the same flow as above.
 
-**BMC or a similar platform component requirements for recovery support**
+## Notes / Assumptions / Outside Streaming Boot Spec Scope 
 
-1. It should not send payload to streaming boot interface (/I3C target)  device if RECOVERY_CTRL register has byte 2 indicating Image Activated. BMC must wait to clear the byte 2. (Streaming boot Interface is responsible for clearing this bye by writing 1).
-2. It must send payload to I3C target device in chunks of 256 bytes ( header (4B) + FW bytes(256B) as I3C target transfer ) only unless it is the last write for the image. Before sending the payload, it must read FIFO empty status from INDIRECT_FIFO_STATUS register.
-3. After last write for the image, it must activate the image after reading INDIRECT_FIFO_STATUS register, FIFO empty status.
+- ROM will refer to I3C registers by offset, and any change to the offset will result in ROM failure or unexpected behavior.
+- SoC will be responsible for booting the I3C Core with the following registers:
+  - Values must be confirmed against latest I3C core specification for up-to-date settings. 
+    - `SOC_I3CCSR_I3C_EC_SOCMGMTIF_T_R_REG = 0x00000002;`
+    - `SOC_I3CCSR_I3C_EC_SOCMGMTIF_T_HD_DAT_REG = 0x0000000A;`
+    - `SOC_I3CCSR_I3C_EC_SOCMGMTIF_T_SU_DAT_REG = 0x0000000A;`
+    - `SOC_I3CCSR_I3CBASE_HC_CONTROL = 1 << I3CCSR_I3CBASE_HC_CONTROL_BUS_ENABLE_LOW;`
+  
+- SoC will be responsible for assigning static addresses to the I3C Core.
+- Caliptra ROM/runtime firmware will update the `RECOVERY_STATUS` Bit [7:4] with the recovery image index.
+- SoC/MCU ROM can set the `HW_STATUS` register per recovery spec at any time based on SoC-specific conditions.
+- MCU ROM will program `DEVICE_ID` register value based on associated fuse values.
+- SoC/MCU ROM initializes the `PROT_CAP`, `DEVICE_ID`, and `DEVICE_STATUS` registers:
+  - `PROT_CAP` register byte 0: MAGIC STRING.
+- Caliptra ROM will perform read-modify-write (RMW) only for updated bits.
+- I3C device must update FIFO size (1-256 Byte), Max transfer size and type of region (tie this to 0x1) to `INDIRECT_FIFO_STATUS` register, which could be read by BMC firmware to understand the size of the FIFO & max transfer size.
+- BMC is responsible for re-sending the transaction if it fails due to PEC error.
+- For recovery Image index:
+  - `0x0`: Caliptra firmware
+  - `0x1`: SoC Manifest
+  - `0x2`: MCU firmware
+
+## Requirement for Payload Available Signal Implementation
+- **Name**: `payload_available`
+- **Type**: 1 bit wire
+- **Source**: Recovery Interface
+- **Destination**: Caliptra core
+
+### Assertion
+- The `payload_available` signal must assert if recovery FIFO indicates full (256B) or image activation status is asserted (essentially indicating the last transfer is complete).
+
+### De-assertion
+- The `payload_available` signal must reset if recovery FIFO indicates empty.
+
+
+## BMC or a similar platform component requirements for recovery support
+
+1. It should not send payload to streaming boot interface (/I3C target) device if `RECOVERY_CTRL` register has byte 2 indicating Image Activated. BMC must wait to clear the byte 2. (Streaming boot Interface is responsible for clearing this byte by writing 1).
+2. It must send payload to I3C target device in chunks of 256 bytes (header (4B) + FW bytes (256B) as I3C target transfer) only unless it is the last write for the image. Before sending the payload, it must read FIFO empty status from `INDIRECT_FIFO_STATUS` register.
+3. After the last write for the image, it must activate the image after reading `INDIRECT_FIFO_STATUS` register, FIFO empty status.
+
+
 
 # Life Cycle Controller & SoC Debug Architecture
 


### PR DESCRIPTION
Caliptra SS streaming boot specification
--
Caliptra SS Streaming boot specification were updated based on discussion around firmware, I3C and OCP specification. Changes include,

- Updates for I3C Core Image Size register
- Updates for DEVICE STATUS Register
- Updates for Payload_available signals implementation
- Notes, assumption regarding Caliptra SS streaming boot specification scope.
