### PR TITLE
updates to Firmware Authentication Key requirements

### DIFF
--- a/CaliptraChecklistAndEvaluationMethodology.md
+++ b/CaliptraChecklistAndEvaluationMethodology.md
@@ -107,13 +107,13 @@ The following is a consolidated list of all requirements to ensure comprehensive
 ### FW Authentication Keys
 
 * **Checklist Item:**  
-  * **Requirement:** Firmware authentication keys MUST be generated using an [ESV](https://csrc.nist.rip/Projects/cryptographic-module-validation-program/entropy-validations/esv) certified entropy source, and key derivation functions specified by [NIST SP 800-208](https://csrc.nist.gov/pubs/sp/800/208/final) and [FIPS 186-4](https://csrc.nist.gov/pubs/fips/186-4/final).
-  * **Requirement:** Firmware authentication keys MUST NOT allow unauthorized users to perform signing operations.
+  * **Requirement:** Firmware authentication keys MUST be generated in accordance with [NIST SP 800-208](https://csrc.nist.gov/pubs/sp/800/208/final) and [FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final).
+  * **Requirement:** Signature generation operations using the firmware authentication key MUST only be allowed by authorized entities.
   * **Requirement:** Firmware authentication keys MUST be stored in a manner that prevents disclosure of private key material. The manner of storage MUST only permit keys to be exported or copied to systems that enforce the same controls on usage and disclosure of the key.
-  * **Requirement:** Signing operations performed using the firmware authentication key MUST be logged.
+  * **Requirement:** Signature generation operations using the firmware authentication key MUST be logged.
   * **Requirement:** Firmware authentication keys SHOULD be created and stored in a Hardware Security Module (HSM).
   * **Requirement:** Firmware authentication keys SHOULD require multi-party authentication to perform signing operations.
-  * **Evaluation Methodology:** Manufacturers MUST describe their key management practices, including storage solutions, access controls, and procedures to prevent unauthorized access.
+  * **Evaluation Methodology:** Manufacturers MUST describe their key management practices, including storage solutions, access controls, and procedures to prevent unauthorized usage.
 
 ### IDEVID Generation and Endorsement Flow
 


### PR DESCRIPTION
removed unnecessary 800-90 reference (as this is already covered in 800-208 and 186-5).

Updated reference from 186-4 to 186-5.

other minor wording improvements for consistency/clarity. 