### PR TITLE
Change DEK from 512 to 256 bits when used in MEK derivation.

### DIFF
--- a/doc/ocp_lock/README.ocp
+++ b/doc/ocp_lock/README.ocp
@@ -310,8 +310,6 @@ In this flow, the DEK may be encrypted by a user's Opal C_PIN. Legacy controller
 
 In this flow, the DEK may be the imported key associated with a Key Per I/O key tag.
 
-Note: in this flow, KMB accepts 512-bit DEKs, to support derivation of AES-XTS-512 keys. There are arguments that a 256-bit DEK would be sufficient, as an AES-XTS-512 key is interpreted as a pair of 256-bit keys and therefore can be said to have a total of 256 bits of security strength. However, other interpretations hold that a 512-bit-wide AES key requires 512 bits of input key material. KMB accepts 512-bit DEKs as a conservative measure.
-
 ![Example controller flow to accept an injected DEK](./diagrams/dek_injection.drawio.svg){#fig:dek-injection}
 
 ### MEKs {#sec:meks}
@@ -1195,8 +1193,6 @@ Table: LOAD_MEK output arguments
 
 This command derives an MEK using the FEK, the MEK secret seed, and the given CEK and DEK.
 
-The DEK may be a per-MEK value in Key Per I/O. It is 512-bits to support AES-XTS-512.
-
 When deriving an MEK, the MEK secret seed is initialized if no PMEK has previously been mixed into the MEK secret seed.
 
 The derived MEK, specified metadata, and aux_metadata are loaded into the encryption engine key cache. The metadata is specific to the storage controller and specifies the information to the encryption engine on where within the key cache the MEK is loaded.
@@ -1217,8 +1213,7 @@ Table: DERIVE_MEK input arguments
 |              |        | by the controller as part of a cryptographic  |
 |              |        | purge.                                        |
 +--------------+--------+-----------------------------------------------+
-| dek          | u8[32] | "Data encryption key". May be a value         |
-|              |        | decrypted by a user-provided C_PIN in Opal.   |
+| dek          | u8[32] | "Data encryption key".                        |
 +--------------+--------+-----------------------------------------------+
 | metadata     | u8[20] | Metadata for MEK to load into the drive       |
 |              |        | crypto engine (i.e. NSID + LBA range).        |
@@ -1620,6 +1615,8 @@ The following acronyms and abbreviations are used throughout this document.
 | HKDF         | HMAC-based key derivation function                       |
 +--------------+----------------------------------------------------------+
 | HMAC         | Hash-Based Message Authentication Code                   |
++--------------+----------------------------------------------------------+
+| HPKE         | Hybrid Public Key Encryption                             |
 +--------------+----------------------------------------------------------+
 | IETF EAT     | IETF Entity Attestation Token                            |
 +--------------+----------------------------------------------------------+

--- a/doc/ocp_lock/diagrams/dek_decryption.drawio.svg
+++ b/doc/ocp_lock/diagrams/dek_decryption.drawio.svg
@@ -1,15 +1,36 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="821px" height="211px" viewBox="-0.5 -0.5 821 211" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7ZndU6MwEMD/mj56w4fQ+mhpqzfqnTO9mdMnJ0IKGYFwIf26v/4SSIAAvdZKa0/PByfZJJtk97fJkvZMJ1pdEZAEd9iDYc/QvFXPHPUMY9C/YP+5YC0Ehp0LfIK8XKSXgin6DYVQE9I58mCqdKQYhxQlqtDFcQxdqsgAIXgpugl1MxyqsybAhw3B1AVhU/oTeTQQu7C0Un4NkR/ImXVNtDwD98UneB6L+XqGOcv+8uYISF2ifxoADy8rInPcMx2CMc1L0cqBITetNFs+brKhtVg3gTHdZYBhCE8tQDiHcs12yAYPPbRgRZ8XpWiGmVpu9hCTrLP9a47zDqaW/VVF+dhx7JJ1QqHHBo7GN1IVW1OuTZ2BiZV5MyPRtXRMZlrIF6+x5mWAKJwmwOWtS0YikwU0CllNZ0UQIj9mZZcZA7L1DheQUMS8fCkaIuR5XPOwcAPX6ocgTUU5ZcpR7N/CGVUlQ0wpjlTZD5wIwQyFoVMYyRxbjjOZFPupukd4jK8Mrioi4a4riCNIyZp1Ea3nA4GOCC1TVJclp7qkK6gwei5kQISGX2gu8WAFQcgGWqSSw9GSEaJ5MGMG4ZhVXuD6M0LDkekKGtNUoSnOq+NQox+ammuc0rOE4AXifn4dLJ0u5HsC+Nadp/uv3/5D+zZojXdl1mgwezmenl05dy3EiONqR8+ymVgeA7d7tWbbyaQ729ZvkSMb12w5EOpWir1LnslxqjmmyFWNA1eIPlTKjxzIL5aojVaCz6yylpWYrfShWqmM4tVyWFaT4zYaPMVz4sLa5UgB8SGtcQQ9JeNsOqZieKvF7lJGYAgoWqh5apszxAz3GGWn2Aa/n9s1f+Y7EqOqieM2RYOaotwKDUUZG8W2d8Sl38DlfngzmpxkZOnvG1mDDxlZ8htQiaz+aUWWpvq9SMxfHVl1Rf0DRlbb19+/j0u/DRftpHBpHBP74mJoWxR1iIvVlsjviUuJyGOlZRsuJSGPCiBvwsVowWVwWve2qXeEi13/EjzgvW037+2uXwvmBDwz8sQc6Wf85Coel/iOxVOq/lf6d09m+pZKS8tj00UL9EYXqYzdvJtuoc+Ol4bf2Ga4P1NK8AuUlolxDNvcVLWe6FPx6kYnttGg8nII89tWw952i73rh8Fe9pZpxgFfgpMARpBkLySfN16LJ5IjxKt9xHiVN2aFn+wx92M5rQMnNd5e+k0vHe4LcdDh28vp5HDyZ6xTfnuxasGpW3vmcA1FneVwrFr+9ph3L3/fNcd/AA==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="261px" viewBox="-0.5 -0.5 831 261" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7Vldb9owFP01eeyUDxLgEQK0U9utUidtfZrcxASrScwc87VfPzuxSRyHFWhgbB2VqvjYvo7PPZd7bQzHT9bXBMxn9ziEsWGb4dpwRoZt97p99p8DGwHYXgFEBIUFZJXAI/oJBWgKdIFCmCkDKcYxRXMVDHCawoAqGCAEr8QwYW6KY3XVOYigBjwGINbRryikM7EL1yzxG4iimVzZMkXPMwheIoIXqVjPsJ1p/im6EyBtifHZDIR4VYGcseH4BGNaPCVrH8acWklbMW+yo3f73gSmdJ8Jdk84Zgnihdj8Dc6oeDu6kYzke4J8lmk4w9UMUfg4BwHvXTEJMGxGk5i1LPY4RXHs4xiTfK4zGfA/hmeU4BdY6THzD+sBMYpShsVwyt57uISEIuaOgYAp5itkbEGURnf5mFGXIfp2BQPcAFxXILH9a4gTSMmGDVmrktuozVXpdqsrsFnF5bbUAhBSi7aWS7rZg2B8B/t2X2PfsL2YUxCiJXuMaL7LAppitksuesmf92OBiwGSyQpUzB2nAdnMKfOcbY7Gt9IUe7PCmroCg5V13yIC6dKA+QaSBqcmKAy55eE2CLjVKAZZJp5Vh1eQIaYUJyr2hWskB2ryG7u+P5m0oxa3Lhe3QS92g146bchFGjmdXHKJmCHMRYNwyhovcPMeVcM105ZqHE9VTe+sorEOEQ2jJVXcJxVSZrYroagBz8oEpJnkZqjr6fMc8Jfxvz98/FSRS7HKfxUdpiL3D4rI1kQ0GD9eXfv3DVoSXx97OpatxMo6eHhVMTldgJ75a91piNA6S2k44IUtFzVXKQpUcuAa0W9cgx9c0Xqq9IzWQp55YyMbKXvTyiTefKr2ldPylpy3k/AML0gAa8mKAhJBWtMRDJUCXHdMhXi3gXeJERgDipZq2d7kDLHCA0Z5UtyRzjt1fxY7ErOqdfRrhryaoYIFzVCuje2295RLV49FEuGUYw/D29HkIkOsXmif9+ur116EWZX4KqPttQhT4qsMt7dFmDwaKxHWvagI69Sy1lYGh0aYZqh+AGszwpqOZX+/XLpNcjEvSi4s86qJ+Fi51KslzVCLcnGbKuy/P3/bDXLpXVb+tvq1uq3XUv5mJ+STycXT83fbp/gFAc9MeWKN7D2e37e3PnzH4obZ+q36969luq6qFkevZfoNorfbKGU8PTfdwYh9vWh+Y5vJT/TKpWuKU9jkpip7YkzFqzud2KQGVS+noN9zNb69Br7rMXwU3/Ly94RXtPMZTCDJL0reb7xub0rOEK/eGeNVZsyKfvJL1n/LaS04qX4Hs6X/LCfEXpt3MMeU/NYpSn75+9Il38F0nJrfzSNrOM1QazUca5Y/yRbDy5+9nfEv&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
         <g>
-            <rect x="460" y="30" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="0" y="10" width="170" height="250" fill="#fafafa" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(250, 250, 250), rgb(22, 22, 22)); stroke: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 50px; margin-left: 461px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 161px; height: 1px; padding-top: 17px; margin-left: 9px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Host
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="9" y="29" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                        Host
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="500" y="150" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 170px; margin-left: 501px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -21,20 +42,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="54" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="560" y="174" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Encrypted DEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="310" y="100" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="350" y="80" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 120px; margin-left: 311px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 100px; margin-left: 351px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -46,50 +67,45 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="370" y="124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="410" y="104" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         DEK decryption key
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="0" y="100" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="25" y="80" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 120px; margin-left: 1px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 100px; margin-left: 26px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
-                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            Host-provided
-                                        </font>
-                                    </div>
-                                    <div>
-                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                        <span style="background-color: transparent;">
                                             Opal C_PIN
-                                        </font>
+                                        </span>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="60" y="124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Host-provided...
+                    <text x="85" y="104" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Opal C_PIN
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <ellipse cx="520" cy="120" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="410" cy="170" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 120px; margin-left: 461px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 170px; margin-left: 351px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     AES-GCM
@@ -100,57 +116,57 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="410" y="174" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         AES-GCM...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 430 120 L 453.63 120" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 458.88 120 L 451.88 123.5 L 453.63 120 L 451.88 116.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 410 120 L 410 143.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 410 148.88 L 406.5 141.88 L 410 143.63 L 413.5 141.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="220" cy="120" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="260" cy="100" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 120px; margin-left: 161px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 100px; margin-left: 201px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    PBKDF
+                                    Argon2 PBKDF
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="220" y="124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        PBKDF
+                    <text x="260" y="104" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Argon2 PBKDF
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 120 120 L 153.63 120" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 158.88 120 L 151.88 123.5 L 153.63 120 L 151.88 116.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 145 100 L 193.63 100" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 198.88 100 L 191.88 103.5 L 193.63 100 L 191.88 96.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 280 120 L 303.63 120" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 308.88 120 L 301.88 123.5 L 303.63 120 L 301.88 116.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 320 100 L 343.63 100" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 348.88 100 L 341.88 103.5 L 343.63 100 L 341.88 96.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 520 140 L 520 163.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 520 168.88 L 516.5 161.88 L 520 163.63 L 523.5 161.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 410 190 L 410 213.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 410 218.88 L 406.5 211.88 L 410 213.63 L 413.5 211.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="730" y="30" width="90" height="20" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="740" y="30" width="90" height="20" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 40px; margin-left: 731px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 40px; margin-left: 741px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -162,20 +178,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="775" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="785" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Durable values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="745" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="755" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 15px; margin-left: 746px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 15px; margin-left: 756px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Legend
@@ -183,20 +199,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="775" y="18" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="785" y="18" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Legend
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="730" y="60" width="90" height="20" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="740" y="60" width="90" height="20" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 70px; margin-left: 731px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 70px; margin-left: 741px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -208,20 +224,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="775" y="73" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="785" y="73" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Ephemeral values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="460" y="170" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="350" y="220" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 190px; margin-left: 461px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 240px; margin-left: 351px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     DEK
@@ -229,15 +245,15 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="194" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="410" y="244" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         DEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 520 70 L 520 93.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 520 98.88 L 516.5 91.88 L 520 93.63 L 523.5 91.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 500 170 L 476.37 170" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 471.12 170 L 478.12 166.5 L 476.37 170 L 478.12 173.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
     </g>
     <switch>

--- a/doc/ocp_lock/diagrams/dek_injection.drawio.svg
+++ b/doc/ocp_lock/diagrams/dek_injection.drawio.svg
@@ -1,122 +1,15 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="821px" height="211px" viewBox="-0.5 -0.5 821 211" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7Zhbb5swFMc/TR47ESgkeWzTpJXWSpMyaeujCydg1WBmnNs+/Ww4XAxkibokatXlIbKP7WP7/H++MXCm8fZekDR64gGwgW0F24FzN7Dt8Wii/rVhhwbbKwyhoEFhGtaGBf0NaLTQuqIBZEZFyTmTNDWNPk8S8KVhI0LwDVZDd0vOzF5TEkLHsPAJ61p/0EBGOAvXqu0PQMOo7HloYckL8V9DwVcJ9jewnWX+K4pjUvrC+llEAr5pmJzZwJkKzmWRirdTYDq0ZdiKdvM9pdW4BSTymAb2NQ5kTdgKyjF7TDW+DehaJUOdLE1LrtzqsDMu8srerxUvKjhW/muairZ3s6+aBPDFLpWUJyrzCrvSoxpa4dTsSJmN7vNYyV2pTx5h0HOwVPEmohIWKfF16UYBqWyRjJnKDVWSMBomKu2rmIAa9u0ahKRK7BssiGkQaM+3lRraa8hIlmE6U85pEj7CUpqWWy4lj03bd56iYUkZm1axcmbudDqfV/NpqoTC6ZHBtmFC1e6BxyCFipqFpddjFA5XmIPZTY3rsIQsaqBa6k1whYSV55oSlUBQ9kEzPDc0DzyTV6nga6plti1IcnzydA7U56NHs3MqehzHpKfavy6Dz6iDz81scXU/feqhCDeOI6VVPakzAg7L2grufH664LaX5oWDO+5Zm+0oJcGNPiU11ppT6pvBgS2VPxvpZ03kFxdzd1sENM/sykyiRvqzmWm00tm6WZ4r2+0NeMZXwofWjiOJCEG2OILAOM27wjQC7/bEvbQJYETStXkH6BMDe/jGab6zoe4jy9S92pNLF8WMsFXzUD7kaNRyVESh4yhno5r2kbhMTodLjchzo+QQLjUhzwYg/4SL9f5x6WwTb8XFtQ44OiEubt/J//FxGfXgMrbfFS7e8ES4TNpn//h8uJQxbOCS397+X8gO3RlGl7wzjJ2eVX3aR+BKkBclCvaRfcYLfPX80zPGbx7Dv25Sx/Mzck1+ep6Dkx567JPQc92h5xFCdQp0dFOT0XpmUvBXKCOT8AT6ZGpGD+s0VN0rYh8NJi/nCL/nduLt9cS7vWe/Ld7uuVfrLI0gBkHYp16v1f5+gfXqXXK9eofvcB9TseoV37vD7NGoR8m9stmtU/qML3uVrT8DF3ev+lO7M/sD&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="261px" viewBox="-0.5 -0.5 831 261" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;5VnJbtswEP0aH1toiWT7aDt2CrQFCqRAkyMj0RIRWlQpesvXdyiNFmpp3cRxisYGDHJIDqn33gxHychdbA43kqTxVxFSPnKs8DByr0eOMxlP4Vcbjmhw/MIQSRYWJrs23LInikYLrVsW0syYqITgiqWmMRBJQgNl2IiUYo/T0N1acHPXlES0Y7gNCO9af7BQxfgUnlXbP1EWxeXOtoUjDyR4jKTYJrjfyHHX+acY3pDSF87PYhKKfcPkLkfuQgqhitbmsKBcQ1vCVqxbDYxW55Y0UacscCZusWRH+JaWZ/Y5LJ6HbAfNSDdL01qAWw07FzKf7P/cimKCa+WfpqlYe72V5AGAxT2y0hccqnBnbgFmY+McJXUsmcmxpfr0FgzvY6bobUoCPboHKYItVhsOPRuahLMogXYAaFA48HxHpWJA8wwHNiwMted5xYP2GnGSZdjOwDlLoi90rUzLXCglNqbtu0jRsGacLyqU3KW3WKxWCCDK3baq52vyhRTqk9JDw4T83VCxoUoeYQqOjktVYqy52N3Xwp2iKW5otlQgwVCJKse1XKCBihlSz1VHPV9oREH9bd7gYTSfmZLikZbIJCKhfTQ10cM5DVYHSexTg6mX14Df9zp4+z14u2fB23vtaF2mMd1QSfi7jlcdrZeKV/+S8Tru6OeTyNTLWGtht5rpbyfWa83VPPOcpQ7LStPSYnJ8HvBtE3u7i7097gPfOwv6k7+JXnj+xGClDNW6xviAoT3T9ZEkSVZiM+8J7CSQx1QBqY51vfzcCN9io/cU1WcQkusZQpr0CMnpEdLVOXQ0nfboqMUQDaGgxS7lD2K/rA3z3AADsZDsCTIcZHswJuFMl86aKQ09C0wag63cVZSbAoClmCT9PO6JVI0+PTB1h050+16v+uhh7/pQOtGdY+URQLmrJ+rufXOsXpb3ynUFDvrhBwtiNGViKwPaikw4eUSrC9vvV0CDY6+H4tImKSeK7cyD9PGOO3wTLL+uUWBVwYAKm3qmh+L8uKhZ4bf8eONWymunsuKZO45AC+TYmJbqCdnwea+c1j7mmwc0Co+1xCtIT1K9a7167ZOnRSukeaJkQmffR3p8j/VP9b4ykBZ7ImowU3rtO9e7YK7EIDZUM1vefrhZfO0RD1J/IrWwE0uzoReP3xRIK+MaehG4rv+m4HbLyS5Kf7hWytuhvhHuGyP/wu1Qaci8HSZveTvY0xbvkxafJ18PrejsvKcOXA/PyuDd+jdPuf9FymwVl2eN6url7zJRfUp5eWpUP6fms42YrkP8zFHt9UX1m9Z8V62az7GeGdUdR2eLaujWf50uptf/AXCXvwA=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
         <g>
-            <rect x="460" y="30" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="740" y="30" width="90" height="20" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 50px; margin-left: 461px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    <div>
-                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            DEK decryption key
-                                        </font>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="520" y="54" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        DEK decryption key
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <rect x="310" y="100" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 120px; margin-left: 311px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    <div>
-                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            Host-provided encrypted DEK
-                                        </font>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="370" y="124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Host-provided encryp...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <ellipse cx="520" cy="120" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 120px; margin-left: 461px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    AES-GCM
-                                    <div>
-                                        decrypt
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="520" y="124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        AES-GCM...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <path d="M 430 120 L 453.63 120" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 458.88 120 L 451.88 123.5 L 453.63 120 L 451.88 116.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 520 70 L 520 93.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 520 98.88 L 516.5 91.88 L 520 93.63 L 523.5 91.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 520 140 L 520 163.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 520 168.88 L 516.5 161.88 L 520 163.63 L 523.5 161.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="460" y="170" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 190px; margin-left: 461px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    DEK
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="520" y="194" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        DEK
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <rect x="730" y="30" width="90" height="20" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 40px; margin-left: 731px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 40px; margin-left: 741px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -128,20 +21,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="775" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="785" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Durable values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="745" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="755" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 15px; margin-left: 746px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 15px; margin-left: 756px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Legend
@@ -149,20 +42,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="775" y="18" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="785" y="18" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Legend
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="730" y="60" width="90" height="20" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="740" y="60" width="90" height="20" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 70px; margin-left: 731px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 70px; margin-left: 741px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -174,14 +67,139 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="775" y="73" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="785" y="73" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Ephemeral values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="0" y="100" width="120" height="40" fill="#ffffff" stroke="none" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
+            <rect x="0" y="10" width="170" height="250" fill="#fafafa" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(250, 250, 250), rgb(22, 22, 22)); stroke: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 161px; height: 1px; padding-top: 17px; margin-left: 9px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Host
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="9" y="29" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                        Host
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="25" y="80" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 100px; margin-left: 26px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    <div>
+                                        <span style="background-color: transparent;">
+                                            Encrypted DEK
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="85" y="104" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Encrypted DEK
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 145 100 L 410 100 L 410 143.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 410 148.88 L 406.5 141.88 L 410 143.63 L 413.5 141.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="500" y="150" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 170px; margin-left: 501px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    <div>
+                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                            DEK decryption key
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="560" y="174" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        DEK decryption key
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <ellipse cx="410" cy="170" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 170px; margin-left: 351px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    AES-GCM
+                                    <div>
+                                        decrypt
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="410" y="174" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        AES-GCM...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 410 190 L 410 213.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 410 218.88 L 406.5 211.88 L 410 213.63 L 413.5 211.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="350" y="220" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 240px; margin-left: 351px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    DEK
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="410" y="244" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        DEK
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 500 170 L 476.37 170" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 471.12 170 L 478.12 166.5 L 476.37 170 L 478.12 173.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
     </g>
     <switch>


### PR DESCRIPTION
An AES-XTS-512 key has 256 bits of security strength and therefore it is acceptable to derive it from 256-bit inputs.