### PR TITLE
Expand MEK secret derivation in LOCK spec.

### DIFF
--- a/doc/ocp_lock/diagrams/mek_derivation.drawio.svg
+++ b/doc/ocp_lock/diagrams/mek_derivation.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="541px" viewBox="-0.5 -0.5 831 541" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VzrU9s4EP9r8hHGzzw+QhJKp+XKHDe9cl9ujC0cTR0rJzsh6V9/ki051gNw/GogwNBaa1uydn+72l2tPbCny+0n7K0WNygA0cAygu3Ang0sazyakH8pYZcT3KGVE0IMg5xk7gl38BdgRINR1zAAiXBhilCUwpVI9FEcAz8VaB7G6Ildxrp7RJE46soLgUK4871Ipf4Ng3TBpuUae/o1gOGCj2wa7MyD5/8MMVrHbLyBZT9mP/nppcf7YtcnCy9ATyWSPR/YU4xQmh8tt1MQUdZytuX3XT1ztnhuDOK00g1cUhsvWrPJT1GcYhRFAFPWQbx8It2xx013nEXZJAHtxhjYl08LmIK7lefTs08EE4S2SJcRaZnk8BFG0RRFCGf32lcX9JfQEzLQT1A6Y2Q/5IwXwTAmtAg8kolcbgBOIZHPBSOniI6QkAFhHH7NrpmNCEWdP2MJ7QBsSyTGj08ALUGKd+SSrYjBndh82uOgoC1KGHAdRvQY9sKi5z3/yQETgV4ck6EiDYXxICBQZc0EhEsy0/medAni4IJqADnrR16SQF8Uhb/Gm0JsohDJrUwVh5lsPJyW2mQcvPtRXEoa97Rx7vLmbFs+Odvx1hamP9jg9Lh0F2ntb6INfs+zYkzQGvtcSScMu+RBQ1Coop0TKZteFHdJoK5OnoyGQeSlcCMaBp2M2Qi3CJJnLtBkOSKcxhJK8gmxm8qKKvfjSrC0pI5yJigdESx4u9JlK3pBomCy4Es1mKpGo5l94NruE3kTs6Pq+xIGQQbvwmDSXkMKcHYs2oIS5RKlKVqKtL+o+cgIkmWaTq+uptN2DInrChKbjBVDUgixDLw27IhpWBoJDSNqSgO4IYdhmk0yJz2iDGp+wYfhf2uUX8AtcomU33s9/8JvJ0+T9yD2SsjCWO8CIHOXQqQlgIxEnbbH6lrTIUTsriEyuz1JiFCAtAYR0YbYTq8IcbtGyA01IkYCfAzS7IAI+wMxjRDjSP6r1atRMc2uIfMn8AI63RtqXAwQ+3i3SiGKSeMn2J0qetryWWT0mJrwp0P0qEvSxfzu7NP0RgOiAGSiryhaMhJcJeDwUPWqPdVUfPh+mauz5u9GATqT0aRPGVk6n+xY4n8Wx/NgvUocX+QMzMFBOYNnBSnE/3yxOeb43xy2E//bEwmXQ6mjPuN/06qQACjjNEYxEGFYoKlA0H3pzCtoKgHoXsBPIzTZOjS5FdHUECaOIcHErQkTef2W8fYMTOqAwFZzDNdfZldvYunt1yu2D0zrvgl1cTXqwiHRtbrYliROo66+yB3ZHerLqDUU9LAEv+wMVMOI8VsxIq2YhWlsuvTaE7czjHBzc9QOYD0bZAlGyGzFCHEsCQAzqq7ZPe0AyfCRTUxdHDqNt4Cq+RC2a7z4XI7z4vXkIH+C+kqhJpWO1tGQEyj95vQd1SVrOf1297Ht0xQiUk6/UON+EHJghqEdV7SBu8CVv2t3wZWtWF0zLXfkyH5Hm+5ChZzeW3IXPOyzHizJezDcsei/Wq87sKR1CzAkDKW24xAg6lIBlYHYk1vx3ObxoXhVVqxJN25FETFK47TnJryJ4ikVyaNaSNarl/GielVDP3cijhr91itGti76q1rrpujn47SG/lH35Rxr7D0QNWFjJCftB9IZM/02X1St6n7hSMpRamo9JhqNkqPAWm7hyOkaPd8RVfgTh0+xVd8DfEZ9wkf1Q7+CkCyJitzIZNKBXPjNggxFTGXuqYHIs0LUoUHESxfsH4oGXrO3P9SwX44yarF/rLL/O2E+wmcBeIQxLaoyVhj5IElUj6hp0iTwkkXGWLOT8LjfnZpJ5/VL1yhJz4gwNjA4uNit1Qf5tvLo1Kf/3n7+g/xPbrSML7efvw1OupCqtTygdS7hWJfm4fF7+zjWJQJlzX8l2Oku0cO1TIgwxkeWtpcCgzNZLnXf3FA6ajEfNKmS3fttYh/r8nvGkdXryIUCo5piVzqqmFapJfbOvff5agGWAGcrxmm7731Ff8UrpX347xPVgZyXK6tBHBI3spkUW38H9IGJTvMaqCxctx0ZKTuwrmZN13n5hTCb7d10ruYzgOEmCxduTnOfr8taekcTkXcXybi6SEZ2Bd5YzZmj8xu5VnReojkWxVl7g1DpqEvPYPw6Cj40dWhKS6/To6JqX6bu7pWpD5veCCkjESl9vsFjcSfifSpze6XeQ1FG/KMa/cio8wTiCWtxaxDhnyMqysetPiGiJmn+ARgNWA52iTDIjXVCXR1KJzLyF3RY8hcSDybmDroB6TUP2feGZDG/250WV1ythxoTbGtk18ZOi2XoQrB6XnXJpz7qGn42wd9SlOdIZR71a/hln7u7ojxL89mEuZfpb/7O+hJusxAbUjVO1zg+HdVVSsutUZ/KqxaIfY5hCglLf2US8ag1NbZ03T0/P1fE8spSqRWXRjod8NUxRJuoN4pjla/cfB3AV9Lcf58u14/9NwDt+f8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="541px" viewBox="-0.5 -0.5 831 541" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7Vxtc5s4EP41/pgMr375mNhO22lzzVxueu19uSGgYE0x8gmc2P31J4GE0UsSjBF14iSTFi0god1nV7urhYE7XW4+4GC1uEYRSAaOFW0G7mzgOOORS/6lhG1J8MeTkhBjGJUke0e4hb8AI1qMuoYRyIQLc4SSHK5EYojSFIS5QAswRo/sMtbdPUrEUVdBDBTCbRgkKvVvGOULNi3f2tE/Ahgv+Mi2xc7cBeHPGKN1ysYbOO598VOeXga8L3Z9tggi9FgjufOBO8UI5eXRcjMFCWUtZ1t539UTZ6vnxiDNG90wYoJ5CJI1m/wUpTlGSQIwZR3Ey0fSHXvcfMtZVEwS0G6sgXv5uIA5uF0FIT37SDBBaIt8mZCWTQ7vYZJMUYJwca97dUF/CT0jA/0EtTNW8UPOBAmMU0JLwD2ZyOUDwDkk8rlg5BzRETIyIEzjL8U1sxGhqPNnLKEdgE2NxPjxAaAlyPGWXLIRMbgVm487HFS0RQ0DvseIAcNeXPW84z85YCLQi2MyVKShMB5EBKqsmYF4SWY635EuQRpdUA0gZ8MkyDIYiqII1/ihEpsoRHIrU8VhIZsA57U2GQdvv1eXksYP2jj3eXO2qZ+cbXlrA/PvbHB6XLuLtHY30Qa/50kxZmiNQ66kE4Zd8qAxqFSRmR7KpmfFXROor5Mno2GQBDl8EA2DTsZshBsEyTNXaHI8EU5jCSXlhNhNdUWV+/ElWDpSRyUTlI4IFoJt7bIVvSBTMFnxpRlMVaNxmH3g2h4SeROzo+r7EkZRAe/KYNJeYwpwdizaghrlEuU5Woq0v6j5KAiSZZpOr66m024Mie8LEpuMFUNSCbEOvC7siG05GgkNE2pKI/hADuO8mGRJukcF1MKKD8P/1qi8gFvkGqm89+P8M7+dPE3Zg9grIQtjvQmAzH0KkY4AMhJ12h2ra41BiLimITK7OUmIUIB0BhHRhrherwjxTSPkmhoRKwMhBnlxQIT9jpiDEONJ/qvTq1GxbdOQ+RMEEZ3uNTUuFkhDvF3lEKWk8RNsTxU9XfksMnpsTfhjED3qknQxvz37ML3WgCgChegbipaMBFcZ2D9UvepONRUfvl/m6qz5m1EAYzKa9CkjR+eTHUv8z+J4Hqw3ieOrnIE92Ctn8KQghfifLzbHHP/bw27if3ci4XIoddRn/G87DRIAdZymKAUiDCs0VQj6UTvzAppqAPoh4OcgNLk6NPkN0XQgTDxLgonfEiby+i3j7QmYtAGBq+YYPs+u+HqcrVd8MbZra3SN3P0aHQXZorBmtpnFoF9f2t0zGfwqlMzXKBkHkmklcx1JnFZbLZM7cg1q2agzFPSwcD/vQjTDiPVbMSKts5VBPXTBdie+MYxwc3PUbmM7G+QIRsjuxAhxLAkAs5qu9D3tG8nwkU1MWxx6B28cNfM8XN969rk879nryUH5BO2VQk1FvTH3RE7W9Lt/4KnuX8epvtv3LaZDISLtH1TK3w9C9sxmdOPAHuBkcJNh2snwZdvX1rjLHXmyt9Klk9Egf/ianIwAh6wHR/I5LH8ser3Oy24vad0ADAlDqe3YB4i6tENjIPbkjDy1Ub0vXpUVa2LGGaniTGmc7pyLV1GopSJ51ArJevWynlWvZujnTsRRo995wci2RX9Ta30o+vk4naF/ZL50ZI2DO6ImbIzspP1AOmOm3/azqtXcLxxJmU1NXclEo1Fy7NjKLRx5ptHzDVGFP3H4VGUBPcBn1Cd8VD/0C4jJkqjIjUymCPWFInMWZChiqnNPDUSeFKIODSJeTLB/KBp4TR3BUMN+Ocpoxf6xyv5vhPkIn0XgHqa0gMtaYRSCLFM9omPLoEjhcb/7OxPjtVIfUZafEWE8wGjvwrpOH+TrKqBTn/578+kP8j+50bE+33z6Ojjpoq3OSv6ccwnHujQPj9+7x7EuEShr/gvBjrlED9cyIcIYH1myXwoMzmS5tH1LROmow3zQpEl277eJfazL71lHVhsklxeMWopd6ahhWqWV2I177/PVAiwBLlaM03bf+4r+qtdX+/DfJ6oDOa9XcYM0Jm7kYVLs/H3TOyY6zSunsnD9bmSk7Nv6mjVd5+VXwjxs78a4ms8Ahg9FuHB9mvt8Juv2PU1Ebi6S8XWRjOwKvLJKNU/nN3KtMF4OOhbF2XqDUOnIpGcwfhkF75o6tKWl1+tRUbUvbpt7Pevdph+ElJGIlD7fFnK4E/E2lbm7t4WGooz4Bzz6kZHxBOIJa3FnEBk6AkQc/mmGfiCiJmn+ARgNWA52iTAojXVGXR1KJzIKF3RY8hcTDyblDroF6TV3xbeNZDG/2Z0WX1ythxoT7Gpk18VOi2PpQrB2XnXNpz7qyn82wd9SlOdJZR7tK/9ln9tcUZ6j+UTDPCj0t3w/fgk3RYgNqRrna5yejuoqBenOqE/lVQvEPqUwh4SlvwqJBNSaWhu67p6fnytieWGp1IpLIx0DfPUs0SbqjeJY5Ss3X3vwlTR338Ir9WP3vUF3/j8=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -166,7 +166,7 @@
             <path d="M 300 178.88 L 296.5 171.88 L 300 173.63 L 303.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="300" cy="290" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="300" cy="290" rx="60" ry="20" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -175,13 +175,16 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 290px; margin-left: 241px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    HKDF
+                                    KDF
+                                    <sup>
+                                        1
+                                    </sup>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="300" y="294" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HKDF
+                        KDF1
                     </text>
                 </switch>
             </g>
@@ -199,7 +202,7 @@
             <path d="M 430 311.12 L 433.5 318.12 L 430 316.37 L 426.5 318.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="460" cy="390" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="460" cy="390" rx="60" ry="20" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -208,13 +211,16 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 390px; margin-left: 401px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    HKDF
+                                    KDF
+                                    <sup>
+                                        1
+                                    </sup>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="460" y="394" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HKDF
+                        KDF1
                     </text>
                 </switch>
             </g>

--- a/doc/ocp_lock/diagrams/mek_generation.drawio.svg
+++ b/doc/ocp_lock/diagrams/mek_generation.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="611px" viewBox="-0.5 -0.5 831 611" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7V1bc5s4FP41fkyGqy+Pie1cJs020+xk233pUFBsphh5BU7s/vqVQGB0SYwxku046TSDDiCBznfO+XQkkY49nC2vkTef3sMARB3LCJYde9SxrH5vgH8TwSoXuF0rF0xQGOQicy14DP8AKjSodBEGIGEuTCGM0nDOCn0Yx8BPGZmHEHyll9HqnmHEtjr3JkAQPPpeJEr/CYN0Sl/LNdbyGxBOpkXLpkHP/PL83xMEFzFtr2PZz9lPfnrmFXXR65OpF8DXisged+whgjDNj2bLIYhI1xbdlt939cbZ8rkRiNNaNxSaevGiBX35IYxTBKMIINJ1IZq94uro46aroouylwSkGqNjX75OwxQ8zj2fnH3FmMCyaTqLcMnEh89hFA1hBFF2r311Qf5heYIb+g0qZ4zsB5/xonASY1kEnvGLXL4AlIZYPxdUnELSQoIbDOPJl+yaUQ9LxPenXUIqAMuKiPbHNYAzkKIVvmTJYnDFFl/XOChl0woG3AEVehR7k7Lmdf/jA6oCuToGXUEbQseDAEOVFhMwmeE3Ha9FlyAOLogF4LN+5CVJ6LOq8BfopVQbq0R8KzXFbqYbD6WVMm4Hrb6Xl+LCD1I4d4viaFk9OVoVpWWYfqeNk+PKXbi0vokUinveVGMCF8gvjHRAsYsfdAJKU7RzIemmd9VdUagr0yeVIRB5afjCOgaZjmkLDzDEz1yiyXJYOPU5lOQvRG+qGipfj8vB0uIqyjtBqAhjwVtVLpuTCxIBk2W/1IOp6DR28w+FtftY39jtiPY+C4Mgg3fpMEmtEwJwesz6gorkEqYpnLGyv4n7yAScZxoOr66Gw3YciesyGhv0BUdSKrEKPKcFP2IalkRD3Yi40iB8wYeTNHvJXPQMM6j5ZT90/1vA/ILCI1dE+b0347vidvw0eQ1srVjMtPUhADJ2CURaAkiXtWm7L8YahRCxVUNk9HCSECEAaQ0irA+xHa0IcVUj5J44ESMBPgJpdoCV/YmYnRDjcPzV0upUTFM1ZL4BLyCve0+ciwFiH63maQhjXPgNVqeKnrY4C48eUzL8UYgeMSRdjB/Prof3EhAFIFN9TdXilsJ5ArYfql61Z5oCh9fbuTJv/mEMQJmOBjp1ZMk42aGM/+k4vhis1xnHlzkDs7NVzuBNRTLj/yLYHPL43+Q4ftPxvz3gcNnlKtI5/jetGgmAKk5jGAMWhiWaSgT9qJzZgKYKgH4w+NkJTbYMTW5NNO0IE8fgYOI2hAkfv3m8vQGTJiCwxRzDzd3o6ihCr15WbG+Z1j0Kc3El5lJAQrW52BanTqOpvfAV2QrtpdcaCjSE4PfJQD2MGHvFCBcxS9e4a+i1B64yjBTu5qAJYDMfZDFOyGzFCRVYYgBm1I3ZmmaAePjwLqYpDp2dp4DqcQjbNd59Lsd593p8kD9Bc6MQk0oHSzT4BIrenL4jUrKW02+Pn9M+u0KEy+mXZqwHIVtmGNqhojvQhcL4VdMFl/diTd00X5HD84426UKNnN4x0QUP+bQGi2MPhttn+au1mcDi0gNAIe5Q4ju2AaIsFVAbiJpoRe+NQLMtXoWIxS9kaolWlCNGrp32aMJRLJ4SkdxrhGS5eRnvmlc99Bck4qDRb21wsk3RX9db74r+op320C9mF8aeP+0UM6WzcEkm142QzJSmCxQLtoHpS9rh12TS+C8QsSo/EjnCmzRNxvdYOyKUkhqO+S5m6xMuYUBj0b6qMi5bAlaeAjRiXD3162wWyPuFu5e2kZw0QVeAnx6XPJYswhlI0MMPz5uhx1GNnidIPPGJw6dcQ6EBPj2d8BEHCF/ABHOV0/H+vS4beSWLLrqqfH9f7P4n3PkQnQXgOYyzgDxH0AdJIlLVXbNZgZdMs441leQt9E6hDZQvLLuBSXqGlfESBluvQmz1Qb7OPfLqw58Pt391SIde4d93D7dfOye9xK21DK11zgFZloArMivtA1mWouVNf8MwVF0KrjAzZuzXP7AJFY7On/F6abqnRqioxUzdoE7edW9q78syr8aBraTil3D0GqpdqKhmwquR2pXT9/F8CmYAZSHjtPm7ruFfudlXB4F3lAPofusZvXbxW13Bf/dJb3amN3xC09VJ010ZTefD3JGtdHNknKiwS+ULQ/usOhtPSwoVqYx6/c0oOF5LbWuvTdfkwoqj0VClW7jVbdQ6TZ/eGlJ6LFJ07huyCrbzMY25vQXmXVZHxac89OhIeXbshK24NYgUH0EqF61bOiEiJiD+BQhiCX5Xy5hBBHJnnRCqQ+RYR9n8sYf/TzCDIQQ937Adkmt+ZV854tX8YacRXDZadyUuWNUUsmWIc/tv74ulW6KPaF8sP2Rxda6ItAwZWd3zCPvTd274VIpeiJgiBRp9u7z+eQ1igLxU/DjaIVhVb69WJf0QRLNEQCUNsNf9xiUMqomA0n3oTgSUeZ1dEwGuuvXJGF8fDwWFwlkU9PSgoMuvJWmKAqEilSjYy54DxUlB54BQ4LaFAqW+QP1UWM58s1U1J8q5FO5T0ssftt0IexSRoyfxGeaeJhIc/gMiTfmDo27LvCXZ+XnsKCg/zbmXXW4Ov4e46doZoSJ+NUabKBBH6LdxmIbY6/7JnL1H8lHGkkSF8/NzASEbnLc0VyVJTSlIKjkGm1WSp5X6oo8t7GAnH+vK2HmrEfn26RSDMJf4EOAgAU39xIfOVbeWKzJ3LYmPnbpMSHzo7TIZzT3wkMVFnc1MxpVskKXuRDlxEcYojRMfCkOWu+XGbIjSKZzA2Iu22Y7acAfqVh9iaYLGpqiSMCNKmkVU6Vl0yn8fqhwEbQ0+i53Dr/vxls3gw8X13wvJL1//TRZ7/D8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="611px" viewBox="-0.5 -0.5 831 611" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7V1tc5s4EP41/pgMr8b+mDhOmklzzTQ3vfa+dCgoNlOMfAIndn/9SSBh9JIYY4TtOOk0gxaQQPvs7qOVRHr2aLa8Qf58eg9DEPcsI1z27KueZQ08G/8mglUhcAfDQjBBUViIzLXgMfoDqNCg0kUUgpS7MIMwzqI5LwxgkoAg42Q+QvCFXkare4Ix3+rcnwBJ8Bj4sSz9JwqzKX0t11jLP4FoMmUtmwY988sPfk8QXCS0vZ5lP+U/xemZz+qi16dTP4QvFZE97tkjBGFWHM2WIxCTrmXdVtx3/crZ8rkRSLJaN3hUMc9+vKAvP4JJhmAcA0S6LkKzF1wdfdxsxboof0lAqjF69uXLNMrA49wPyNkXjAksm2azGJdMfPgUxfEIxhDl99rXF+Qflqe4od+gcsbIf/AZP44mCZbF4Am/yOUzQFmE9XNBxRkkLaS4wSiZfM6vufKwRH5/2iWkArCsiGh/3AA4Axla4UuWPAZXfPFljYNSNq1gwB1SoU+xNylrXvc/PqAqUKtj2Je0IXU8CDFUaTEFkxl+0/FadAmS8IJYAD4bxH6aRgGvimCBnku18UrEt1JT7Oe68VFWKeN20Op7eSku/CCFc5cVr5bVk1crVlpG2XfaODmu3IVL65tIgd3zqhpTuEABM9IhxS5+0AkoTZG6HtJNb6q7olBXpU8qQyD2s+iZdwwqHdMWHmCEn7lEk+XwcBoIKCleiN5UNVSxHleApSVUVHSCVBHGgr+qXDYnF6QSJst+qQdT2Wns5h+YtQdY39jtyPY+i8Iwh3fpMEmtEwJwesz7gorkEmYZnPGyv4n7yAWCZxqNrq9Ho3YcietyGhsOJEdSKrEKPKcFP2IalkJD/Zi40jB6xoeTLH/JQvQEc6gFZT/0/1vA4gLmkSui4t5P4zt2O36aoga+Vizm2noXABm7BCItAaTP27Q9kGONRojYuiFy9XCSECEAaQ0ivA+xnU4R4upGyD1xIkYKAgSy/AAr+wMxOyHGEfir1alTMU3dkPkK/JC87j1xLgZIArSaZxFMcOE3WJ0qetriLCJ6TMXwRyN65JB0MX48uxndK0AUglz1NVWLW4rmKdh+qHrdnmlKHL7bzlV583djANp0NOxSR5aKkx3K+J+O49lgvc44vswZmL2tcgavKpIb/7Ngc8jjf1Pg+E3H//ZQwGVfqKjL8b9p1UgAVHGawATwMCzRVCLoR+XMBjRVAPSDw89OaLJVaHJromlHmDiGABO3IUzE+C3i7RWYNAGBLecY7q6uWTxOF3MWjM1KjK6I24/RoZ9Oc29m6gkG3XJpe8tk8FEYmaswMgYk3UZmW4I6jaZWJlZka7QyrzUUdBC436YQ9TBi7BUjQpwtHequAdseutowwtzNQdPGZj7I4pyQ2YoTYljiAGbUjfQdzRuJ8BFdTFMcOjtPHNVjHrZrvPlcjvPm9figeILmRiGnot4ZPRGTNd3OHzgy/Ws51ff4McW0K0SE+YPS+LtByJbZjHYI7A4kg7kM3STDFX1fU+cuVuSIbKVNklEjf3hMJMNHAa3BEjiH4Q541mttpr249ABQhDuU+I5tgKhKO9QGYkdkxHsl0GyLVyliiYumWiIj5ThTaKc9cnEUC7VkJHuNkKw2L+NN86qHfkYiDhr91gYn2xT9db31ruhn7bSHfjknMfaDaY/Nys6iJZnINyIyK5stUCLZBqYvOQvn1n/S+C8RsSo/kjnCqzRNxfd4OyKUkhqO+SZm6xMuaRhk0b6qMi5bAVaRAjRiXJ7+NT0L5P/C3UvbSE+aoGvAjyeknBULfoYK9IiD+mbocXSj5xsknvjE4VOu1+gAPl6X8JEHCJ/BBHOV0/H+Xp+PvIoFHn1dvn8gd/833PkQnYXgKUrygDxHMABpKlPVQ0ttCXmLbifehtoXsX2CaXaGlfEchVuveGz1Qb7MffLqo58Pt3/1SIde4993D7dfeie9nK61xZjWuQBkVQKOZVbaB7IqRSua/oZhqL4UHDMzbuw3OLBpGIHOn4l6abp/R6qoxUzdsE7edW9qH6gyr8aBrdoSF354DdUuVVQz4dVI7drp+3g+BTOA8pBx2vy9q+FfubG4CwLvaAfQ/dYzeu3it7pb4O6D3uxMb8SEptslTXdVNF0Mc0e2Ps5RcSJml9oXoQ54dTaelpQq0hn1BptRcLyW2ta+nr4phBWnQ0NVbhfXtynsNH16a0jxeKR0uUfJYmznfRpze3uU+ryO2GdDutGR9uzYCVtxaxDpWxxELPZBiG4gIicg/gUIYgl+V8uYQQQKZ50SqkPkWEf5/LGP/08wgyEEvdgcHpFrfuVfVBLV/G6nEVw+WvcVLljXFLJlyHP7r+/Bpduvj2gPrjhkcbtcEWkZKrK65xH2h+/c8FmWbiFiyhTo6uvlzc8bkADkZ/KH2A7Bqry9WpXyoxPNEgGVNMBe9zaXMKgmAkr30XUioMzr7JoIcPWtT8b4en8oYArnUeB1g4K+uJakKQqkinSiYC97DjQnBZ0DQoHbFgq0+gL9U2EF881X1Zwo59K4T6lb/rDt9tmjiByewmeYe5pIcMSPlTTlD46+jfaWYr/osaOg/AzoXna5OeLO46ZrZ6SKxNUYbaJAHqHfJlEWYa/7J3f2PslHGUsSFc7PzyWEbHDeylyVIjWlIankGHxWSZ1WGsg+ltnBTj7WVbHzViPy7bdTDMJaEx9drrq1XJm5H2Hio9suU9Hc4w5ZJQw44sK8R9fERRqjNE58aAxZ7pYbsyHKpnACEz/eZjtqwx2oW32+pQkaa6JKQYTqD6G7WXQqflWqHARtDT6Ln8Ov+8mXzeDDxfXfJikuX//9F3v8Pw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -166,7 +166,7 @@
             <path d="M 300 178.88 L 296.5 171.88 L 300 173.63 L 303.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="300" cy="290" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="300" cy="290" rx="60" ry="20" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -175,13 +175,16 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 290px; margin-left: 241px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    HKDF
+                                    KDF
+                                    <sup>
+                                        1
+                                    </sup>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="300" y="294" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HKDF
+                        KDF1
                     </text>
                 </switch>
             </g>
@@ -199,7 +202,7 @@
             <path d="M 430 311.12 L 433.5 318.12 L 430 316.37 L 426.5 318.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="460" cy="390" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="460" cy="390" rx="60" ry="20" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -208,13 +211,16 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 390px; margin-left: 401px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    HKDF
+                                    KDF
+                                    <sup>
+                                        1
+                                    </sup>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="460" y="394" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HKDF
+                        KDF1
                     </text>
                 </switch>
             </g>

--- a/doc/ocp_lock/diagrams/mek_loading.drawio.svg
+++ b/doc/ocp_lock/diagrams/mek_loading.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="591px" viewBox="-0.5 -0.5 831 591" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VzbcqM4EP0aPybF1ZfHxHEmU5nspDZbszP7skVAsVWDkVfgxJ6vXwkkjC6JMUbEjieppKABCdSnu49al547nq8+4WAxu0MRiHuOFa167lXPcYaDEflPBetC4PedQjDFMCpE9kbwAH8BJrSYdAkjkAo3ZgjFGVyIwhAlCQgzQRZgjF7Ybay4JxSLtS6CKVAED2EQq9K/YZTN2Gf51kZ+A+B0xmu2LXblMQh/TjFaJqy+nuM+5T/F5XnAy2L3p7MgQi8VkTvpuWOMUFYczVdjENOm5c1WPHf9ytXyvTFIsloPcE09B/GSffwYJRlGcQwwbTqI5y+kOPa62Zo3Uf6RgBZj9dzLlxnMwMMiCOnVF4IJIptl85ic2eTwCcbxGMUI58+61xf0l8hTUtFPULli5T/kShDDaUJkMXgiH3L5DHAGiX4umDhDtIaUVAiT6Zf8nqsBkajfz5qEFgBWFRFrj08AzUGG1+SWlYjBtXj6ssFBKZtVMOAPmTBg2JuWJW/anxwwFejVMeor2lAaHkQEquw0BdM5+dLJRnQJkuiCWgC5GsZBmsJQVEW4xM+l2kQlkkeZKfZz3QQ4q5yTevD6e3krOflBT859fnq1ql68WvOzFcy+s8rpceUpcrZ5iJ7wZ15VY4qWOORGOmLYJS86BaUpuoWQNtOb6q4o1Nfpk8kwiIMMPouOQadjVsM9guSdSzQ5nggnGSXFB7GHqoYql+NLsHSkgopGUAoiWAjWldsW9IZUwWTZLvVgqjqN/fwDt/aQ6Ju4HdXe5zCKcniXDpOWOqUAZ8eiL6hILlGWobko+4u6j1wgeabx+Pp6PG7Hkfi+oLHRUHEkpRKrwPNa8CO25Wg01I+pK43gMzmcZvlHFqInlEMtLNuh/98SFTdwj1wRFc/eTG754+RtihLEUolYqOtDAGTiU4i0BJChaNPuUI01BiHimobI1f1JQoQCpDWIiD7E9TpFiG8aIXfUiVgpCDHI8gOi7N+I2QsxnsRfnU6dim2bhsyfIIjo595R52KBJMTrRQZRQk5+gvWpoqctziKjx9Z0fwyiRw1JF5OHs0/jOw2IIpCrvqZqSU1wkYLdu6rX7ZmmwuG7bVydN/8wBmBMR6MudeToONmh9P9ZP5531uv048ucgd3bKWfwqiKF/j8PNofc/7f77fT/3ZGEy75UUJf9f9upkQCo4jRBCRBhWKKpRNCPypUtaKoA6IeAn73Q5OrQ5NdE054w8SwJJn5DmMjxW8bbKzBpAgJXzTHc3F5dH0Xo7ZYVuzumdY/CXHyNuXBImDYX15HUaTW1F7kg16C9DFpDQQch+G0yUA8j1rtiRIqYpWvcN/S6I98YRri7OWgC2MwHOYITsltxQhxLAsCsujG7oxEgGT6yi2mKQ2/vIaB6HML1rTffy/PevJ8cFG/Q3CjUpNLBEg05gdJtTt9TKVnL6beH38M++0JEyumXZtwNQnbMMLRDRfegC9z4TdMFX/ZiTd20XJAn84426UKNnN4x0YUAh6wER2IPlj8U+auzncCSs3uAIWlQ6jt2AaIuFVAbiB3RisErgWZXvCoRa2SGVpQ9Rqme9mjCUUyeUpE8aIRkvXlZb5pXPfRzEnHQ6He2ONmm6K/rrfdFP6+nPfSr2YVJEM56fKR0Dld0cN2CdKQ0W+JEsQ1CX7KePCeTxX+FiFX5kcoRXqVpOr4n2hGllMxw7DcxW59wKR0ah7VVlXG5GrDKFKAR4xqYn2ezxMEjaV5WR3rSBN0AfgZS8lgzCWekQY/cPW+GHs80er4h6olPHD7lHIoO4DPoEj5qB+ELmBKucjref9AXI69m0kXflO8fqs3/jTQ+wmcReIJJHpAXGIUgTVWqum82KwrSWd6wtpG8RbdDaCPjE8tuUJqdEWU8w2jnWYitvsjXRUA/ffzv/ec/erRBr8n/2/vPX3snPcWttQytcy4BWZeA45mV9oGsS9HKpr+lG2ouBcfNTOj7DQ9sQEWi82eyXpquqVEKajFTN6qTd303tQ91mVfrwGZSyVM4Bg3VrhRUM+HVSO3G6ftkMQNzgPOQcdr8vavuX7nYtwsC7xkH0N3OI3rt4rc6g//2N73Zm97ICU2/S5ru62i6HOaObKabp+NE3C6NTwyV1wg2HZZUCjIZ9YbbUXC8ltrWWpu+LYUVr0ND1S7hNrdQ6zR9emtIGYhI6XLdkMPZzsc05vYmmPdFHfGtPLrRkfHs2AlbcWsQ4ZsglZPWnS4hoiYg/gEYEQn5VseaIwwKZ51SqkPlREf5+HFA/qaEwVCCXizYhvSex3yXI1nNH3YYwRejdV/jgk0NITuahfhCtwkkU5gc2hZNj8zONLs0yZbot6Qiaa2dr+mo27qxnrJHv5+WdPOP3rmr/mGccGub8kjdIL/L2beOpU7S+UgL3OXcQ7eNazvbiWq93MMuW5U13Rbt1eau5h5KwFRzD6WjMZ176MsTF5pOslMcs7mBFkezh0RDFBxQBsrToWDwPijw/YYoUAoyNzGeNJnpWMwIWD6F40TjssFFMd1Gjl1XXR5D5LDf02fIyWavray1V3PbiyY+Q7PMsGnkaIICI1uk8BTDuyyp8uQFq00naigFyUP/baJAHbv4nMAMEq/7K3f2AU1+WCsaFc7PzxWEbHHe2sSIJg9iIIPhWWIKQ5/DGKo+ltvBDj6WnG42sS7UsNko3J38Dw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="591px" viewBox="-0.5 -0.5 831 591" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VzbcqM4EP0aPybF1ZfHxHFmpjLZSW22Zif7skVAsVWDkVfgxJ6vXwkkjC6JMUbEsSeppKABCdSnu49al547nq8+4WAxu0URiHuOFa167lXPcYYDl/yngnUh8IejQjDFMCpE9kZwD38BJrSYdAkjkAo3ZgjFGVyIwhAlCQgzQRZgjF7Ybay4JxSLtS6CKVAE92EQq9K/YZTN2Gf51kb+GcDpjNdsW+zKYxD+nGK0TFh9Pcd9yn+Ky/OAl8XuT2dBhF4qInfSc8cYoaw4mq/GIKZNy5uteO76lavle2OQZLUeGDDFPAfxkn38GCUZRnEMMG06iOcvpDj2utmaN1H+kYAWY/Xcy5cZzMD9Igjp1ReCCSKbZfOYnNnk8AnG8RjFCOfPutcX9JfIU1LRT1C5YuU/5EoQw2lCZDF4Ih9y+QxwBol+Lpg4Q7SGlFQIk+nX/J6rAZGo38+ahBYAVhURa49PAM1BhtfklpWIwbV4+rLBQSmbVTDgD5kwYNibliVv2p8cMBXo1THqK9pQGh5EBKrsNAXTOfnSyUZ0CZLogloAuRrGQZrCUFRFuMTPpdpEJZJHmSn2c90EOKuck3rw+kd5Kzl5oCfnPj+9WlUvXq352QpmP1jl9LjyFDnbPERP+DOvqjFFSxxyIx0x7JIXnYLSFJnroc30prorCvV1+mQyDOIgg8+iY9DpmNVwhyB55xJNjifCSUZJ8UHsoaqhyuX4EiwdqaCiEZSCCBaCdeW2Bb0hVTBZtks9mKpOYz//wK09JPombke19zmMohzepcOkpU4pwNmx6AsqkkuUZWguyv6i7iMXSJ5pPL6+Ho/bcSS+L2hsNFQcSanEKvC8FvyIbTkaDfVj6koj+EwOp1n+kYXoCeVQC8t26P+3RMUN3CNXRMWznyc3/HHyNkUJYqlELNR1FACZ+BQiLQFkKNq0O1RjjUGIuKYhcnV3khChAGkNIqIPcb1OEeKbRsgtdSJWCkIMsvyAKPs3YvZCjCfxV6dTp2LbpiHzJwgi+rm31LlYIAnxepFBlJCTn2B9quhpi7PI6LE13R+D6FFD0sXk/uzT+FYDogjkqq+pWlITXKRg967qdXumqXD4bhtX582PxgCM6WjUpY4cHSc7lP4/68fzznqdfnyZM7B7O+UMXlWk0P/nweaQ+/92v53+vzuScNmXCuqy/287NRIAVZwmKAEiDEs0lQh6qFzZgqYKgB4E/OyFJleHJr8mmvaEiWdJMPEbwkSO3zLeXoFJExC4ao7h5uqax+N0ueDB2K7E6Iq4/RgdBeks92a2mWDQLZd2d0wGfwgj8zVGxoFk2shcR1Kn1dTK5IJcg1Y2aA0FHQTutylEPYxY74oRKc6WDnXfgO2OfGMY4e7moGljMx/kCE7IbsUJcSwJALPqRvqOxo1k+MgupikOvb0HjuoxD9e33nwvz3vzfnJQvEFzo1BTUUdGT+RkTbfjB55K/1pO9d3/HmLaFyLS+EFp/N0gZMdsRjsEdg+SwV2GaZLhy76vqXOXC/JkttImyaiRP/xIJCPAISvBkTiH5Q9F1utsp73k7A5gSBqU+o5dgKhLO9QGYkdkZPBKoNkVr0rEGpkhI2U/U6qnPXLxISZqqUgeNEKy3rysN82rHvo5iTho9DtbnGxT9Nf11vuin9fTHvrVnMQkCGc9Pio7hys6kG9BOiqbLXGi2AahLzkLF+Z/svivELEqP1I5wqs0Tcf3RDuilJIZjv0mZusTLqUb5LC2qjIuVwNWmQI0YlwD83N6ljh4JM3L6khPmqAbwM9ASjlrJvyMNOiRO/XN0OOZRs93RD3xicOnnK/RAXwGXcJH7SB8BVPCVU7H+w/6YuTVTPDom/L9Q7X5v5PGR/gsAk8wyQPyAqMQpKlKVQ8ttSXlLbodeBsZn8T2GaXZGVHGM4x2nvHY6ot8WwT008f/3n35o0cb9Jr8v7n78q130tPpWpuM6ZxLQNYl4HhmpX0g61K0sulv6YaaS8FxMxP6fsMDG4aR6PyZrJem63eUglrM1I3q5F3fTe1DXebVOrBZW/LEj0FDtSsF1Ux4NVK7cfo+WczAHOA8ZJw2f++q+1cuLO6CwHvGAXS784heu/itrha4+U1v9qY3ckLT75Km+zqaLoe5DzY/ztNxIm6XxiehyusRmw5LKgWZjHrD7Sj4uJba1rqevi2FFa9DQ9UuFze3KOw0fXprSBmISOlyjZLD2c5xGnN7a5T6oo74tiHd6Mh4duyErbg1iPQdASIO3xCiG4ioCYh/AEZEQr7VseYIg8JZp5TqUDnRUT5+HJC/KWEwlKAXi8Mhvecx31FJVvPRDiP4YrTua1ywqSFkR7PoX+g2gWQKk0PbDuqR2ZlmRyjZEv2WVCSt6/M1HXVbN9ZT9uj305Ju/tE7d9WPxgm3tgGQ1A3yu5x961jqJJ1jWkwv5x66bVzb2U5U6+UedtkWrekWbK82dzX3UAKmmnsoHY3p3ENfnrjQdJKd4pjNDbQ4mv0qGqLggDJQng4Fg/dBge83RIFSkLmJ8aTJTMdiRsDyKRwnGpcNLorpNnLsulbzI0QO+z19hpxs9trKWns1t9ho4jM0ixObRo4mKDCyHQtPMbzLkipPXubadKKGUpA89N8mCtSxiy8JzCDxur9yZx/Q5Ie1olHh/PxcQcgW561NjGjyIAYyGJ4lpjD0OYyh6mO5HezgY8npZsPsQg2bTcndyf8=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -166,7 +166,7 @@
             <path d="M 300 178.88 L 296.5 171.88 L 300 173.63 L 303.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="300" cy="290" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="300" cy="290" rx="60" ry="20" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -175,13 +175,16 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 290px; margin-left: 241px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    HKDF
+                                    KDF
+                                    <sup>
+                                        1
+                                    </sup>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="300" y="294" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HKDF
+                        KDF1
                     </text>
                 </switch>
             </g>
@@ -199,7 +202,7 @@
             <path d="M 430 311.12 L 433.5 318.12 L 430 316.37 L 426.5 318.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="460" cy="390" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="460" cy="390" rx="60" ry="20" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -208,13 +211,16 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 390px; margin-left: 401px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    HKDF
+                                    KDF
+                                    <sup>
+                                        1
+                                    </sup>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="460" y="394" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HKDF
+                        KDF1
                     </text>
                 </switch>
             </g>

--- a/doc/ocp_lock/diagrams/mek_secret_derivation.drawio.svg
+++ b/doc/ocp_lock/diagrams/mek_secret_derivation.drawio.svg
@@ -1,15 +1,15 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="832px" height="1142px" viewBox="-0.5 -0.5 832 1142" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7V1tc5u4Fv41nmk/xMM75mPiOG2nzb2dZufe7ac7xFZstth4ATfJ/vorAcLoSLYxlhTHdrvTNQIkOOfRedPRoWcP5y+f0nA5u08mKO5ZxuSlZ9/2LCvwDfwvaXgtGzzXKRumaTQpm8x1w0P0D6oaq/umq2iCMubCPEniPFqyjeNksUDjnGkL0zR5ri6runtKYnbUZThFXMPDOIz51v9Gk3xWtg5cY93+GUXTGR3ZNKozj+H41zRNVotqvJ5lPxV/ytPzkPZVXZ/Nwkny3GiyRz17mCZJXv6avwxRTEhLyVbed7fhbP3cKVrkrW7wg/KW32G8ql5+mCzyNIljlBLSRen8GXdXPW7+SklUvCQi3Rg9++Z5FuXoYRmOydlnjAncNsvnMT4y8c+nKI6HSZykxb323TX5i9szPNAv1DhjFH/wmTCOpgvcFqMn/CI3v1GaR5g/11VznpARMjxgtJh+K6659XEL//4VSUgH6KXRVNHjE0rmKE9f8SUvLAZf2cPnNQ7qtlkDAwPK0rDC3rTueU1//KNiwSZ22Bw7epYXExJMot/45zQv3rJsesKcKmYBpZ/39yopL6CUbDSV996u0vARM7EaI6N94Ucru2OHwM3MwIeggPJ0jJmDwcVzdR5NJqTnm3pakF6ncZhl1W+W442WmyTPkznb9gcBSdEA8Ddyh8O7u4qAlfQxDTnw8V0WPw6Pn0AAHznocVSj5z9JHObRmcOHgGc41AMfXyd8XA4+39AUYV0G+YZfJufE9yJZIBGbmtSrrmlwdSMTRWhg8aKC/J67S/p7AvLbMsgfKJ+9o+UMzVEaxmc/fXVJ/9ow1DB/LXugGkA/UDghb3v//SvtJls90rNGAzaN5nPFWKEiJGDKZUWSxyPKtASQcmRAinaiHFJeOCe8XDxmy0aHmMwLBg707mqIa3wynT5+wP3idzHo/z6WXYCRGqAlAC267oRQqe+PFuP0dZlHCXnRX+j1MlsOmy0e8N9EFpTC+WJy8+V69HD1aXgvgM0EFaxvyVo8UrTMNllGW5ztu0rdSSBuTcw3kUWWQBZBIk2m6KE6zNB0jl91tG7Ck21yTcJDBPQExdGYJd14lf6uZw87l/Ctla3gFZZvmOaNYzxO+vpn1Utx8JPc13fp4e1L3Q85eqVHL1H+5/pKfPSzcWZ9Ezmg92zkY5as0jECkhs/6BRRK4PCk5BpK78bDHUF/KRtKSLu4G82aiZicjXC9yQqJCSdqx4LJxfApHyh6qZmFAv048CYjQk6KonAdYSxEL42LluSC7ItzwvgP2CCa/hH2eEazjVFWyJcefTnYri1dQ4USEvT1iouRe7kFnHJu+Zi4WRuFU61IGzIvp/NcxsEYUuhRhcDGKFmtxRqB0or22HZeUXn/97yiu8JBhA2CKxOQoWP6nTEgdlAwRoTu3Cwn0JshwPq6XZTbofiwNqhbVrDAHYE9Z9MFHiqVcuXRZRHRWipUDJGhq1blG/y7DbolI0O33ph7arh++VpuMgoWAQu3wfjhTxsv9//uNv1uyizbcrMsd9Umfm7hRgm5pL8xEZ8/HqTYsAQ0bCLWWvOkqM4fETx9ySLCoecW378Bk7XjKQsT8v33szxNMnD6uarQFLQ0TFY1giWnESMsQ0pnOGDjp+/3t5djV7w5BznvKo5AjfWBlFaSxClVYhlfsldhZW/FsAXI16i3LOpmaEFKy4fT9IZf90AmmocXkuTE1dZERYh6tk0li9CvSwlvmvA0awNo20O/JrnOjsUrU3oDba6fEDwlIOtmokrikW9c7fRFYUPKIpUu43mwGTZGXR2Gz1WI3nq3EZXFETSEJFsCuZLRFKZSNFszIhiEBcnjlIYSHuXZ406L87l/et358U5plYwK0+2uXhx6rw419VpS1EFfUpLMdRsYm0pR48tBRdQOptSoB9T4TqMx3srJ5xKtXG4tiECa8cA5yYJFXnszkCrIOSdylP22DUTV9qC//F47FRoMlrG07TgDz12F5raXT1211eoZkTL/Ro8dkZeXzx2VSJFs+HKe+zvzi30LK0Ua7FQ/d5MfSpvWSHs6hHC0ETn4h1dbX0b8lumEBYFBy6RLjrPgJUkyCJXF+mi8vQSt3kP6s8LWKz4WgPWvnKX/ZZxpC8QkbA9Ti9ClGfsP4zOEiF1iQb5CNEsQ/b0yrXuWupgaobpuOrBUm95UgHMWJ7+oKXlqWcTk+WzUQIfdtF+F9OA7cgGHUnaxWSaYD4Y5tbngjsqwfWHb3sS1J04ninSEd/qNvb5Im/M949rTlhgTriy5gTsSNWcsLbPCQfsXATXS5gTojjCxbA4LsMCerKaLQvlGQgX70SC7fmmEBFtNdiiWVH8mDzvo1ffTpXuCIiSF8G/KYRaa1ca8Wa1q3FU2tUB+wYdiJW22tUF8sttmUm6r3Z1B+w4nuyN87T/S7xVJIIsp0/3z9WuhdunuTo7oq6O5fcDX4Isooup72ktyQGrb4HWgicDfvXtX0mOysQZlnZGcdr4fH89/JCFWDUX2Ttfvt5/3GISNJq+kGSdfBZlhYmwyPJ0NS5rEpF+yh6N4mwYx1f/oDQhtePIuZCUByQj0Qv2Suc2ev6Q/Ce+zdp9W7/f32SLtLJQ2lQyrGa5ljqGlhzgApc9GPBWhy3SUFABdMJtwEvjH2iJQoKhJ0w+rEjD8axHN4rnCXmwWVQ05TNSW/Se+CYlnB4JqfpbUPyY7mK5ilulptP9QSgwQSkxCSgJnqJFuZl+1FhNIt0eso1dYd3OsiLzbrBLADfM5RXsdzZ9ZeDeqMaWoaBS6jFoMRcEK0xDRDFlaiywdhtn7ywlwjYEBUhsQ1Nemguzlg2YT9baAeB6gpnUEpMiAuUlSIbEcgmL+863vO3olvwFZoUkycuVtxUUAVFW3jZQXjdh3VIq48n/5ugXc9n5okkGerhPK4j0kKFID9XpQxL0UEMLtc6P3rMyZCs9VM8JJlxFTRTleogrdt21IJrnQn9FmRqqtbTCBLC9V1YuFYWPOIRvg+ilaQq+CqDMfLaNE0sgUZsxQgMdrGF+XBkjLiylZnQtfAvtd79lBcG9A/jcE8PvSsElCs6xYG84OORvG8r3udyWNiCNwZynEJW27RDGIEzKwJ1C1JUhRHnf898/ODYdx2dtZFDb4CxtntqqPmRTi9t3FCLjdLzWEJlt7LlOn6T5LJkmizBWtlj/LjR7e1dHk2bn1F7X2sAO51upKw5s04c8oQhtjQzWENS0aY3nXtcKFVxPdaaiChworza5biHifXmJsMmNsFkc7rRG2ExLlhw5mgoE9Zzo5lAeKEd8WCG+80oP3EjH9ySzauCe+uSo0w73giKfdvjXar4EeG+nwBzhNw6Co7J3TIdNm78yu+7OdkCG2pWqb/hA18iSHJiw3FPKuX0r8NN6hGx1seMK48GvTjmdN7kA7JuGmk0uEPqOLXnTirvnRi610OfhqHP9rgn9aWF8thT7hgj51lEhHy7XdV3242vrK5L58JuQgez88z3XaLQDXxqIuzj6BwC/dakvTcCH9ZM7h3egFRIoEvkwV9KQvAxjKl9N/3yeiy8y9ylacLeqzk1otslvZR2RxG/AppNZfLGBkPADntqOgNgykuRss0Xlqb0mhIDSkzCb1VuiZMAT7pG0eYLVNobshG7bVJ5WWKDdQOVenSIt5/zEGUjI4cAhgNDmCQaU2oDGtrSIM9rxqe41PIw1ftCn9KCbPb1Bn25V37HXEIvKvozV/loE6d1qKBfUVC7pAbV1AfVG1njeUYCat7SPHtSe9aagFnnll1KPR6rVPZObZZoVu7QPZevLggBxkd3LmbSRWc4sZ6X01UtYcdeF2WVdS/e2rVPRJaBhiXapnRwKBDXEKnEpPxcGhLoGXtANBbCjAK41dkYBPkwTItjXl2OZO7tPJohc8X8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="851px" height="1091px" viewBox="-0.5 -0.5 851 1091" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7V1tc5u4Fv41nmk/xMO7zcfEcdpOm91Os3Pv9tMdbCs2W2y8gBO7v/5KgDB6wcZYkklMu9MFAUdG59F509GhZ46W20+Rt148hjMQ9Axttu2Z9z3DGA5c+C9q2GUNtmNkDfPIn2VN+r7hyf8N8kYtb934MxATNyZhGCT+mmychqsVmCZEmxdF4Wt+W07uOQzIXtfeHDANT1MvYFv/68+SRf5atrZv/wz8+QL3rGv5lYk3/TWPws0q769nmM/pn+zy0sO08vvjhTcLX0tN5rhnjqIwTLKj5XYEAjS0eNiy5x4qrha/OwKrpNYDmFMvXrDJX34UrpIoDAIQoaHzo+UrJJf/3GSHhyh9SYDIaD3z7nXhJ+Bp7U3R1VeICdi2SJYBPNPh4bMfBKMwCKP0WfPhFv2F7THs6BcoXdHSP/CKF/jzFWwLwDN8kbsXECU+5M9t3pyEqIcYduiv5t/Se+4HsIV9/3xIEAGwLTXl4/EJhEuQRDt4y5bE4I48fd3joGhblDAwxCz1cuzNC8r78YcHOQuq2GEy7OgZToCGYOa/wMN5kr5l1vQMOZXOAjx+zr+bMLsBj2SpKXv2fhN5E8jEvI8Y04I/LSNHdgGbiY7PQQHm6RQyB4KL5erSn80Q5btiWiCq88CL4/yY5Hip5S5MknBJtv2FQJI2UPgb26PRw0M+gLn00TUx8BnYJH4sFj8uBz5i0GPJRs9/wsBL/CuHDwLPaKQGPgOV8LEZ+HwDcwB1Gc03+DIJI75X4Qrw2FQevfyeElcrmchDA4kXGcPv2Mekv8MZflPE8LvSZ+94vQBLEHnB1U9fVdK/MAwVzF/DHMoG0A/gzdDbPn7/isnEmwm+qpVgU2q+VoylKkIApmxSJDksonSDAylLBKQwEemQcrwl4uVqEq9LBOEwrwg44KfzLm7hxWg++QDpwnfR8P8+ZiSonkqgRQBNSTdCqND3B6tptFsnfohe9BfYdbPlvNniaKQE5llQEueLzsyX2/HTzafRIwc2M5CyviZrYU/+Oq6yjA442w+5uhMwuIXwuYgsMjiyiB6k2Rw85acxmC/hq473TXCyzW5ReAiBHqHYn5JDN91EL8XsIecSfDS3FZzU8vWipHQO+4l2f+dU0pOf6Lm+jU/vtwUddLbDZ1s/+Xt/Jzz7Wbqyfwid4Gcq+RiHm2gKKMkNf+gcYCsDwxMN00F+lxhqc/iJ2yKA3MEXMmrGY3Lew/fQTyUknquUtWRTMMleKH+oHMWi6FjUnNd1ilA2CAwhiAVvV7ptjW6ID/xeCv5DIrgGDzKCezgXI1oT4dKjP53hVtc5kCAtdVOpuOS5kwfEJeua84WTflA4FYKwJPt+lq9VCMKaQg0vBhBCzawp1M6UVqZJsvMGz/+T5RVLiQ4gVAisRkKFjeo0xIFeQsEeE8dwcJpCrIcD7Ok2U27n4sA4om1qw4AmROs/kShwZKuWLys/8dPQUqpktBhatyCp8uwqdEqlw7dfWLsp+X5J5K1iDBaOy/dB26If2+/3Px53/TpldkiZWTRY1SqzwXEhBgdzjQ6hER/s7iIIGCQajjFrz1l0FngTEHwPYz91yJnlx2/U5YKRmOVR9t7VHI/CxMsfvnEFBR1Nl2QNZ8mJxxhTE8IZNuj4+ev9w814CyfnNGFVTQvcWNMiB8zgRGklYpldcpdh5e8FcGfEC5R7JjYzlGDFZuNJKuOvFaDJ+2G1NLpwE6dhEaSedW295eplIfFdje7NqOitOvCrX+vskLQ2oTbYarMBwfccbFU8uLxY1Bt3G21e+ACjSLbbqA91kp1uY7fRITWSI89ttKXnJPAjkmXB3EUkpYkUxcYMLwbROXE9rhNXCCslXpzN+tdvzouzdKVglp5s03lx8rw421ZpS2Gp+56WYrDZRNpSlhpbil5AaWxKUXR0iesweAvMdaRSVXZXN0RgHOng2iShJI/dGioVhKxT+Z49dsWDK2zBvz0eOxaahJZxFC340x67TZvaTT12eyBRzfCW+xV47IS87jx2WSJFseHKeuxvzi10DKUjVmOh+q2Z+ljekkLYViOEaROdiXc0tfVNmt8ihTAvONBFunrcSJfFySKXF+nCqleefvw8/nqNWq/YVC0AIs6QhMhAaZx6IN1Tv/9+lRARaRjRu+LUIkR6ov5TJ0QEI0SxDDnRGVe6WamBhelF05yCId/gxAKYMDgHg5oGp5q9S8aADA4MaBK1Ny/pQ5KQSREStHlJ16n5oOmHfxdTiYK4//zdTpxyE+2ZIg3xLW8/34DjhJl63UiYojlhUHPCFjUnaEKy5oRxeE6YVHEo6n4Bc4IXPuhMz3aZnrQDq9iy6BIP3hBWbOuiWOFtNTigYkEwCV9PUbCX06lHAqLoReAxhlBtNYsj3qTpOWyVmrUoLWTRWKmtZilBZtfMJD1VzRbrXdhZF71xHoeLungrTwTRRs7QZkQQTwJBD6eP11/PkkJ4GfUtrSJZVCE4V+l2xyG77vZHmIAsZYYcOy29rH1+vB19iD2olNO8nS9fHz8esApKTV9Qmk6y8OPUSljFSbSZZtWIEJ2MopZe9YLg5jeIQlQ1Dl3zUGFA1BO+4aREbq03GKH/+I8Zxx/r9/tVVkgt26RODcN8fiupYGicCVxck8TR+1j6lbBq8vQRLe4bYdVlZe8PsAYews0zHDKoNr3pooe3hSch+mELP21KFqiS6COKdWYQmqDh6R9A7iQ6xmYZjwpNnvsLjcAMRMgAwEPw7K+yrfPjkumNyJ6zaV1ilc6s/vJxgAuQxNSyrc3Z3awPpIG7UnWtPU5d1DZoLkdzCwGAlZerUnm5xnFj7I2lQJgap+CIqakqPMOUJKfzx2rnQDCU6MxpgUkQrvSSIyNkr3jpc9dbznZ8j/5SxoQg2cuUs+VYwdLK2brS6yTsWzJ1PPvfEvwibrteNElAD1cNaZLUUJEtJEANlZRQ7XToEwtB1lJDxZQgolPYRpGthgYWrTyaFr6iKbnytFChpCWGy09O1egKCLc4Ys9UZdNUVrk1tRMTR8IoWYTzELqP0uL2bRODpsERg4WJ3pIgvc3AqGl1W8M9RkmkuJS+feQ+M7VwsOM6hZW4aueMs69aXrFe3p8/GE6144MxAgacXheAk9EpVkmODbiIz8QUcu4NhaRolao0HmVqJy6Cq9OordlnydWo9R0LRRqV3qzf2P+gvxHBUhKoUTHpdxQOLZBBGmCKdoTRXw3QNVqu1sYBQ0leKS0TV6dREc5C0n3dhbPEhrMMrYYWkxbO0g1RYqQ9WkfnipG6fty5WVSMW9V0VcWiv/PAUBJZke9EddLqlL6ToMim9P2zWa4pvNfTXxb3+wFuq8wd3SQ9jRu96c5nyxxQlCR9H4eeUtTXp8/P87PfUz7rpcCPa/2RlbvaFT2jv+hkNd5JQmFf1+TsJKGhb5mCd4bYJ+6Wkgt9Fo4qo8Rl6M9T27Om2Nd4yDdahXyHWhtr+o0htm69pNxu+nuLrujc7hMXRJQDXxiIm/j5ZwC/dhktRcCnaxM3/qwSbYW4ckQ+vcKDZ4Io5Be7O7sqAy2uMmDQ26RVbvAydfnfkilnJKODdOlOu0bYCC1ITKnNirR9ecjBhLstU7wFK4dZVnVqVqkyBm7fFsGfN7hpil7nG+qaYlAbHaircwXsy4OatWhaD2pHvzSo5X+Dhavj9U7Hn7nx1ry0jj+xGKmCzIeG60nNXWPKu62RCsFblMrs7IstBdA7uJtGQ2kFXbeuThPv1ahRA/VC4DsxUqMSfLwqT5kCuBT46HDKkM6RqF/UiSJUMy7TCHyK/eKrV5SMVuRgvdoZpostKM0PNGt4wm1L0DpVsBQ1OEjBUqHVzt0oxGRW0PsBa28UYjIraEqNZQY8jUI0o/e3w8m2eAxnAN3xfw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
         <g>
-            <rect x="0" y="0" width="210" height="820" fill="#fafafa" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(250, 250, 250), rgb(22, 22, 22)); stroke: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
+            <rect x="10" y="0" width="210" height="820" fill="#fafafa" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(250, 250, 250), rgb(22, 22, 22)); stroke: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 201px; height: 1px; padding-top: 7px; margin-left: 9px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 201px; height: 1px; padding-top: 7px; margin-left: 19px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Controller firmware
@@ -17,20 +17,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="9" y="19" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="19" y="19" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         Controller firmware
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="740" y="30" width="90" height="20" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="750" y="30" width="90" height="20" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 40px; margin-left: 741px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 40px; margin-left: 751px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -42,20 +42,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="785" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Durable values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="740" y="60" width="90" height="20" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="750" y="60" width="90" height="20" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 70px; margin-left: 741px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 70px; margin-left: 751px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -67,20 +67,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="785" y="73" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="73" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Volatile values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="755" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="765" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 15px; margin-left: 756px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 15px; margin-left: 766px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Legend
@@ -88,20 +88,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="785" y="18" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="18" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Legend
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="740" y="90" width="90" height="20" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="750" y="90" width="90" height="20" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 100px; margin-left: 741px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 100px; margin-left: 751px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -113,20 +113,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="785" y="103" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="103" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Ephemeral values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="45" y="50" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="55" y="50" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 70px; margin-left: 46px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 70px; margin-left: 56px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -141,7 +141,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="105" y="74" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="115" y="74" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Ready MPK0
                     </text>
                 </switch>
@@ -241,7 +241,7 @@
             <path d="M 320 118.88 L 316.5 111.88 L 320 113.63 L 323.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 165 70 L 253.63 70" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 175 70 L 253.63 70" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
             <path d="M 258.88 70 L 251.88 73.5 L 253.63 70 L 251.88 66.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
@@ -322,13 +322,13 @@
             </g>
         </g>
         <g>
-            <rect x="45" y="260" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="55" y="260" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 280px; margin-left: 46px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 280px; margin-left: 56px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -346,7 +346,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="105" y="284" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="115" y="284" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Ready MPK1
                     </text>
                 </switch>
@@ -377,7 +377,7 @@
             </g>
         </g>
         <g>
-            <path d="M 165 280 L 253.63 280" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 175 280 L 253.63 280" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
             <path d="M 258.88 280 L 251.88 283.5 L 253.63 280 L 251.88 276.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
@@ -462,13 +462,13 @@
             <path d="M 320 329.88 L 316.5 322.88 L 320 324.63 L 323.5 322.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="45" y="470" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="55" y="470" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 490px; margin-left: 46px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 490px; margin-left: 56px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -486,7 +486,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="105" y="494" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="115" y="494" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Ready MPK2
                     </text>
                 </switch>
@@ -517,7 +517,7 @@
             </g>
         </g>
         <g>
-            <path d="M 165 490 L 253.63 490" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 175 490 L 253.63 490" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
             <path d="M 258.88 490 L 251.88 493.5 L 253.63 490 L 251.88 486.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
@@ -577,7 +577,7 @@
             <path d="M 410 450 L 405 450 Q 400 450 400 460 L 400 590 Q 400 600 395 600 L 392.5 600 Q 390 600 395 600 L 397.5 600 Q 400 600 400 610 L 400 740 Q 400 750 405 750 L 410 750" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,400,600)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="680" y="731" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="680" y="731" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -588,7 +588,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            MPK secret
+                                            HEK
                                         </font>
                                     </div>
                                 </div>
@@ -596,19 +596,19 @@
                         </div>
                     </foreignObject>
                     <text x="740" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        MPK secret
+                        HEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="45" y="631" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="55" y="631" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 651px; margin-left: 46px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 651px; margin-left: 56px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -620,20 +620,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="105" y="655" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="115" y="655" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         DPK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="45" y="731" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="55" y="731" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 751px; margin-left: 46px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 751px; margin-left: 56px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -645,22 +645,22 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="105" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="115" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         SEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 105 671 L 105 691 L 600 691 L 600 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 600 729.88 L 596.5 722.88 L 600 724.63 L 603.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <path d="M 105 731 L 105 711 L 450 711 L 450 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 115 671 L 115 691 L 450 691 L 450 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
             <path d="M 450 729.88 L 446.5 722.88 L 450 724.63 L 453.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="390" y="731" width="120" height="40" fill="#e5ccff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(229, 204, 255), rgb(68, 46, 90)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 115 731 L 115 711 L 310 711 L 310 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 310 729.88 L 306.5 722.88 L 310 724.63 L 313.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="390" y="731" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -671,7 +671,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            SEK
+                                            DPK
                                         </font>
                                     </div>
                                 </div>
@@ -679,7 +679,7 @@
                         </div>
                     </foreignObject>
                     <text x="450" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        SEK
+                        DPK
                     </text>
                 </switch>
             </g>
@@ -696,7 +696,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            DPK
+                                            MPK secret
                                         </font>
                                     </div>
                                 </div>
@@ -704,26 +704,26 @@
                         </div>
                     </foreignObject>
                     <text x="600" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        DPK
+                        MPK secret
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 400 650 L 400 670 L 740 670 L 740 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 740 729.88 L 736.5 722.88 L 740 724.63 L 743.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 400 650 L 400 670 L 600 670 L 600 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 600 729.88 L 596.5 722.88 L 600 724.63 L 603.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 534.47 725.54 L 529.47 725.54 Q 524.47 725.54 524.47 735.54 L 524.47 929.52 Q 524.47 939.52 519.47 939.52 L 516.97 939.52 Q 514.47 939.52 519.47 939.52 L 521.97 939.52 Q 524.47 939.52 524.47 949.52 L 524.47 1143.51 Q 524.47 1153.51 529.47 1153.51 L 534.47 1153.51" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,524.47,939.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 535 775 L 530 775 Q 525 775 525 785 L 525 900.81 Q 525 910.81 520 910.81 L 517.5 910.81 Q 515 910.81 520 910.81 L 522.5 910.81 Q 525 910.81 525 920.81 L 525 1036.62 Q 525 1046.62 530 1046.62 L 535 1046.62" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,525,910.81)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="520" cy="970" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="525" cy="940" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 970px; margin-left: 461px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 940px; margin-left: 466px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Extract
@@ -731,20 +731,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="974" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="525" y="944" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Extract
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="0" y="971" width="350" height="60" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="0" y="851.22" width="350" height="60" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 348px; height: 1px; padding-top: 1001px; margin-left: 2px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 348px; height: 1px; padding-top: 881px; margin-left: 2px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Note: HKDF-Extract = HMAC(salt, IKM)
@@ -765,20 +765,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="2" y="1005" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="2" y="885" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         Note: HKDF-Extract = HMAC(salt, IKM)...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="20" y="530" width="170" height="60" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="30" y="530" width="170" height="60" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 168px; height: 1px; padding-top: 537px; margin-left: 21px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 168px; height: 1px; padding-top: 537px; margin-left: 31px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Repeat for each MPK to which the MEK is bound.
@@ -797,20 +797,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="105" y="549" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="115" y="549" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Repeat for each MPK to which...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <ellipse cx="610" cy="1050" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="669.22" cy="1000" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1050px; margin-left: 551px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1000px; margin-left: 610px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Expand
@@ -818,24 +818,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="610" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="669" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Expand
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 430 1070 L 430 1093.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 430 1098.88 L 426.5 1091.88 L 430 1093.63 L 433.5 1091.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 380 1020 L 380 1043.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 380 1048.88 L 376.5 1041.88 L 380 1043.63 L 383.5 1041.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="740" y="120" width="90" height="20" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="750" y="120" width="90" height="20" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 130px; margin-left: 741px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 130px; margin-left: 751px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -847,20 +847,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="785" y="133" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="133" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Constant values
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="700" y="1030" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="750" y="980" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 1050px; margin-left: 701px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 1000px; margin-left: 751px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -872,24 +872,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="750" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="800" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         "derived_mek"
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 700 1050 L 676.37 1050" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 671.12 1050 L 678.12 1046.5 L 676.37 1050 L 678.12 1053.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 750 1000 L 735.59 1000" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 730.34 1000 L 737.34 996.5 L 735.59 1000 L 737.34 1003.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="370" y="1100" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="320" y="1050" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1120px; margin-left: 371px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1070px; margin-left: 321px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -906,24 +906,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="430" y="1124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="380" y="1074" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         MEK...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 520 990 L 520 1010 L 430 1010 L 430 1023.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 430 1028.88 L 426.5 1021.88 L 430 1023.63 L 433.5 1021.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 465 1000 L 446.37 1000" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 441.12 1000 L 448.12 996.5 L 446.37 1000 L 448.12 1003.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="550" y="1095" width="120" height="45" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="609.22" y="1050" width="120" height="40" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1118px; margin-left: 551px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1070px; margin-left: 610px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -935,20 +935,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="610" y="1121" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="669" y="1074" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Derived MEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="490" y="1035" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="465" y="1046.62" width="120" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 1050px; margin-left: 491px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1062px; margin-left: 466px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     OR
@@ -956,20 +956,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="525" y="1065" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         OR
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <ellipse cx="430" cy="1050" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="380" cy="1000" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1050px; margin-left: 371px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1000px; margin-left: 321px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Expand
@@ -977,28 +977,28 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="430" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="380" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Expand
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 520 990 L 520 1010 L 610 1010 L 610 1023.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 610 1028.88 L 606.5 1021.88 L 610 1023.63 L 613.5 1021.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 585 1000 L 602.85 1000" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 608.1 1000 L 601.1 1003.5 L 602.85 1000 L 601.1 996.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 610 1070 L 610 1088.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 610 1093.88 L 606.5 1086.88 L 610 1088.63 L 613.5 1086.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 669.22 1020 L 669.22 1043.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 669.22 1048.88 L 665.72 1041.88 L 669.22 1043.63 L 672.72 1041.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="240" y="1030" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="200" y="980" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 1050px; margin-left: 241px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 1000px; margin-left: 201px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -1010,15 +1010,15 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="290" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="250" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         "wrapped_mek"
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 340 1050 L 363.63 1050" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 368.88 1050 L 361.88 1053.5 L 363.63 1050 L 361.88 1046.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 300 1000 L 313.63 1000" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 318.88 1000 L 311.88 1003.5 L 313.63 1000 L 311.88 996.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <path d="M 460 210 L 480 210 L 480 324.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
@@ -1048,7 +1048,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            HEK
+                                            SEK
                                         </font>
                                     </div>
                                 </div>
@@ -1056,71 +1056,47 @@
                         </div>
                     </foreignObject>
                     <text x="310" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        HEK
+                        SEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="360" y="781" width="40" height="20" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="400" y="851.22" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 38px; height: 1px; padding-top: 791px; margin-left: 361px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    EPK
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="380" y="795" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        EPK
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <rect x="240" y="721" width="280" height="60" fill="none" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <rect x="320" y="880" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 900px; margin-left: 321px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 871px; margin-left: 401px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            EPK extraction
+                                            MEK secret seed 0
                                         </font>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="380" y="904" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        EPK extraction
+                    <text x="460" y="875" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        MEK secret seed 0
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 389.22 658.78 L 384.22 658.78 Q 379.22 658.78 379.22 668.78 L 379.22 788.53 Q 379.22 798.53 374.22 798.53 L 371.72 798.53 Q 369.22 798.53 374.22 798.53 L 376.72 798.53 Q 379.22 798.53 379.22 808.53 L 379.22 928.28 Q 379.22 938.28 384.22 938.28 L 389.22 938.28" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,379.22,798.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 389.22 650 L 384.22 650 Q 379.22 650 379.22 660 L 379.22 779.75 Q 379.22 789.75 374.22 789.75 L 371.72 789.75 Q 369.22 789.75 374.22 789.75 L 376.72 789.75 Q 379.22 789.75 379.22 799.75 L 379.22 919.5 Q 379.22 929.5 384.22 929.5 L 389.22 929.5" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,379.22,789.75)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="380" cy="829" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="380" cy="820.22" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 829px; margin-left: 321px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 820px; margin-left: 321px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Extract
@@ -1128,23 +1104,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="380" y="833" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="380" y="824" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Extract
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 679.22 658.78 L 674.22 658.78 Q 669.22 658.78 669.22 668.78 L 669.22 788.53 Q 669.22 798.53 664.22 798.53 L 661.72 798.53 Q 659.22 798.53 664.22 798.53 L 666.72 798.53 Q 669.22 798.53 669.22 808.53 L 669.22 928.28 Q 669.22 938.28 674.22 938.28 L 679.22 938.28" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,669.22,798.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 679.22 650 L 674.22 650 Q 669.22 650 669.22 660 L 669.22 779.75 Q 669.22 789.75 664.22 789.75 L 661.72 789.75 Q 659.22 789.75 664.22 789.75 L 666.72 789.75 Q 669.22 789.75 669.22 799.75 L 669.22 919.5 Q 669.22 929.5 674.22 929.5 L 679.22 929.5" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,669.22,789.75)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="670" cy="829" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="670" cy="820.22" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 829px; margin-left: 611px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 820px; margin-left: 611px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Extract
@@ -1152,44 +1128,73 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="670" y="833" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="670" y="824" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Extract
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="609.22" y="880" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="530" y="851.22" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 900px; margin-left: 610px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 871px; margin-left: 531px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            MPK secret
+                                            MEK secret seed 1
                                         </font>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="669" y="904" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        MPK secret
+                    <text x="590" y="875" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        MEK secret seed 1
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 380 849 L 380 873.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 380 878.88 L 376.5 871.88 L 380 873.63 L 383.5 871.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 380 840.22 L 380 871.2 L 393.63 871.21" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 398.88 871.22 L 391.88 874.71 L 393.63 871.21 L 391.89 867.71 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 670 849 L 669.38 873.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 669.25 878.88 L 665.93 871.8 L 669.38 873.63 L 672.92 871.97 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 670 840.22 L 670 871.2 L 656.37 871.21" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 651.12 871.22 L 658.11 867.71 L 656.37 871.21 L 658.12 874.71 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="465" y="980" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1000px; margin-left: 466px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    <div>
+                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                            MEK secret
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="525" y="1004" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        MEK secret
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 525 960 L 525 973.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 525 978.88 L 521.5 971.88 L 525 973.63 L 528.5 971.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
     </g>
     <switch>

--- a/doc/ocp_lock/diagrams/mek_secret_derivation.drawio.svg
+++ b/doc/ocp_lock/diagrams/mek_secret_derivation.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="1032px" viewBox="-0.5 -0.5 831 1032" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7V1tc5u4Fv41nmk/JMM75mPiOG2nzb2dZufe7ac7xFZstth4ATf2/vorAcLoSLYxlhQndrvTBQFHcM6j86YjuWcPZqtPabiYPiRjFPcsY7zq2Xc9y+r7Af6XNKzLBtdzy4ZJGo3LJnPT8Bj9g6pGo2pdRmOUMTfmSRLn0YJtHCXzORrlTFuYpslLdVtF7jmJ2V4X4QRxDY+jMOZb/xuN82n1Wa6xaf+MosmU9mwa1ZWncPRrkibLedVfz7Kfiz/l5VlIaVX3Z9NwnLw0muxhzx6kSZKXR7PVAMWEtZRt5XP3W67W752ied7qASqp32G8rD5+kMzzNIljlBLWRensBZOrXjdfUxYVH4kIGaNn375Moxw9LsIRufqCMYHbpvksxmcmPnyO4niQxElaPGvf35C/uD3DHf1CjStG8QdfCeNoMsdtMXrGH3L7G6V5hOVzUzXnCekhwx1G88m34p47H7fw31+xhBBAq0ZTxY9PKJmhPF3jW1YsBtfs6csGB3XbtIGBPhVpWGFvUlPe8B8fVCLYJg6bE0fP8mLCgnH0Gx9O8uIry6ZnLKliFFD+eX8vk/IGyslGU/ns3TINn7AQqz4ySgu/WkmO7QI3Mx0fgwIq0xEWDgYXL9VZNB4Tyrf1sCBUJ3GYZdUxK/FGy22S58mMbfuDgKRoAPgbuoPB/X3FwEr7mIYc+Pguix+Hx08ggI8c9Diq0fOfJA7z6MzhQ8AzGOiBj68TPi4Hn29ogrAtg3LDH5Nz6nuezJFITE3uVfc0pLpViCI0sHhRwX7qqGzX/p6A/bYM9gfKR+9wMUUzlIbx2Q9fXdq/dgw1jF/L7qsG0A8UjsnXPnz/Sslkyyd61WjAptF8rhgrTIQETLmsSvJ4RJmWAFKODEhRIsoh5YUzIsv5U7ZoEMRsnjNwoE9XXdzgi+nk6QOmi7/FoP/7WJIAPTVASwBakO6EUKnfj+ajdL3Io4R86C+0voyW40aLB+I3kQelcLyY3Hi5GT5efRo8CGAzRoXoW4oW9xQtsm2e0Y5g+74ydxKYWzPzVXSRJdBFkEnjCXqsTjM0meFPHW6a8GAb35D0EAE9QXE0Ylk3Wqa/69HDjiX8aOUreIXnG6Z54xz3k67/rKgUJz/Jc9cuPb1b1XTI2ZqeraL8z82d+Oxn48rmIXJCn9kqxyxZpiMENDd+0QmiXgaFJ2HTTnk3BOoK5EnbUkTCwd9s1kwk5KqH70lUaEg6Vj0WTi6ASflB1UPNLBag48CcjQkIlUzgCGEshOvGbQtyQ7bjfQH8+0xyDR+UBDdwrjnaEuHKsz8Xx61tcKBAW5q2VnUpCid3qEs+NBcrJ3OncqoVYUP3/Wxe26IIWyo1OhnAKDW7pVI7UlvZDivOKzr+D9ZXPCWYQNiisDopFT6r0xEHZgMFG0zsw8FhBrEdDmik2824HYsDa4+1aQ0DSAjaP5ko8FSbli/zKI+K1FJhZIwMe7co3xbZbbEpWwO+zcTaVSP2y9NwnlGwCEK+D8aKvOz19fXH/aHfxZjtMmaO/arGzN+vxDAzF+QQO/Hx+jbFgCGqYZ+wNpIlZ3H4hOLvSRYVATk3/fgNXK4FSUWelt+9XeJpkofVw1eBpKSjY7CiEUw5iQRjG1IkwycdP3+9u78arvDgHOW8qTmBMNYGWVpLkKVViGV+yl2Fl79RwBcnXqLes6mboQUrLp9P0pl/3QKaqh/eSpMLV1mRFiHm2TQWK6FdlpLfNWBv1pbetid+zXMdHYrmJvQmW10+Ifiek62amSvKRb3xsNEVpQ8oilSHjWbfZMUZdA4bPdYieerCRld5TYI4I9lUzJeMpDKVotmZEeUgLkEc5TDQ9i4vGnVRnMvH128uinNMrWBWXmxzieLURXGuq9OXogb6PU3FULeJ9aUcPb4UnEDp7EoBOqbCeRiPj1becSnV1u7apgisPR2cmyZUFLE7fa2KkA8q33PErpm50ib8Tydip0qTsTKepgl/GLG70NXuGrG7vkIzI5ru1xCxM/r6ErGrUimaHVc+Yn9zYaFnaeVYi4nqt+bqU33LKmFXjxKGLjqX7+jq69tQ3jKVsCg5cMl00XEGvCRBFbm6TBfVp5e8zVswf16fxYqvNWHtKw/Z75hA+gIRCcvj9CJEecX+4/AsEVJv0SAfIZp1yIFRudZVSx1czTAdVRQs9Z4nVcCM5+n3W3qeehYxWT6bJfAhifarmPosIRsQkrSKyTTBeDDMne/lAX8N3H/8sifBvhOnM0Q64lvdwj5fFI35/mmNCQuMCVfWmICEVI0Ja/eYcMDKRXC/hDEhyiNcHIvTcixgJKvZs1BegXCJTo73PZ1XhYhoqcEOy4rip+TlELv6eqZ0T0KUfAg+phBqbV1pxpu1rsZJWVcHrBt0IFbaWlcX6C+3ZSXpodbVBVkcT/bCeUr/km8VqSAAF1eggkQayHWDa8OVoIXoNOpbmkVy4FYPtk693efn3f6V5KgsmWF5ZxSXjc8PN4MPWYiNclG38+Xrw8cdzkCj6Qsp08mnUVY4B/MsT5ejcjciQqekaBRXwzi++gelCdk1jlwLycaApCd6w0GF3EbPH5D/xI9Z+x+7vr7e5oW08k3a7GFYjW8tOxhacoALtkIJ+jxubZFtgqq/E24DXg//QAsUEgw9Y/ZhExqOpj26RDxPyItNo6Ipn5JdRR9IVFLC6Ymw6noHip/SfSJX8ajUQro/CAfGKCXOAGXBczQvl9EPG/NIhOwxC9gV7thZ7sW8H+wSwA2reAUrnU1fGbi3mrFFKNgj9RSsmAvSFIHWEvnA2u+VvbFaCNsQ7DxiG5oK0mAwGTiARGvHHxLy2qXVuvjmgfKdRwbEbQmL5853V9vhHfkLfApJapfb1Vaw94eyXW0D5dslbFpKSzz+3wz9Ym47XzTJQA90SUVGyFBkhOqiIQlGqGGCWldFH7gfZCsjVA8JJklF3RPlRggog6Dr3I4HCPVbzu10MEK1hVZY9XXwdMplG+ETztvb/f1xtDLP2TbeWdGI2ioRKhrWJz+tKhEXhK5B1yoR6Lp7kJCsnD144X6wZ0bc2Xn/0Tl+21C+sOWu9P5o6uU8Fai0dYYw9eB7LRWohCkH2+CDzn//4KR0Gj9jI4PZBnSxeWar+t2aWtO+obwYZ9115sVs48BZ+STNp8kkmYexsqn5N2HT24c4mmw6NHn9jjbdgSFVS5vexYya8uLhkwFLIHQANS1Q44QHc6mdUUBngVWggJ/LUJZUI5p9cUmqyU2qWRAsWpNqpiVLiZzMVgP1kOgWRR6pRHxQo9N5ZscL9hCSuTnggabkpKsLDwIiX13413K2AGhvZ7sc4U8ZBCfl6JgOWx1/ZXZdhO3QjdxrSop+qgdGROCHsI8vOXTfU2nta4GfbjvIbiJ2Wpk7+ONSTue1LAD7pqEocwfX19uS16a4B67XUgt9Ho46J+ya0J8UnmdLtW+IkG+dFPK5CbquSp/bQl+Rzoc//RjILjM/cFpGO/ClgbhLjH8E8Fvv6KUJ+HCb5K6/8MRt6hsoUvmwMNKQi3zbVD5//vk8p1xkLke04KJUnWvNbJNfsTokVd5ATO9mzsUGSsIPeG47AmbLKIqzzRYbTB00IAScHofZtF75tIU7Ah62Tln5giU1tY9xZPU2Pk0Tol82Cg9/8vQhGSNyx/8B&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="832px" height="1142px" viewBox="-0.5 -0.5 832 1142" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7V1tc5u4Fv41nmk/xMM75mPiOG2nzb2dZufe7ac7xFZstth4ATfJ/vorAcLoSLYxlhTHdrvTNQIkOOfRedPRoWcP5y+f0nA5u08mKO5ZxuSlZ9/2LCvwDfwvaXgtGzzXKRumaTQpm8x1w0P0D6oaq/umq2iCMubCPEniPFqyjeNksUDjnGkL0zR5ri6runtKYnbUZThFXMPDOIz51v9Gk3xWtg5cY93+GUXTGR3ZNKozj+H41zRNVotqvJ5lPxV/ytPzkPZVXZ/Nwkny3GiyRz17mCZJXv6avwxRTEhLyVbed7fhbP3cKVrkrW7wg/KW32G8ql5+mCzyNIljlBLSRen8GXdXPW7+SklUvCQi3Rg9++Z5FuXoYRmOydlnjAncNsvnMT4y8c+nKI6HSZykxb323TX5i9szPNAv1DhjFH/wmTCOpgvcFqMn/CI3v1GaR5g/11VznpARMjxgtJh+K6659XEL//4VSUgH6KXRVNHjE0rmKE9f8SUvLAZf2cPnNQ7qtlkDAwPK0rDC3rTueU1//KNiwSZ22Bw7epYXExJMot/45zQv3rJsesKcKmYBpZ/39yopL6CUbDSV996u0vARM7EaI6N94Ucru2OHwM3MwIeggPJ0jJmDwcVzdR5NJqTnm3pakF6ncZhl1W+W442WmyTPkznb9gcBSdEA8Ddyh8O7u4qAlfQxDTnw8V0WPw6Pn0AAHznocVSj5z9JHObRmcOHgGc41AMfXyd8XA4+39AUYV0G+YZfJufE9yJZIBGbmtSrrmlwdSMTRWhg8aKC/J67S/p7AvLbMsgfKJ+9o+UMzVEaxmc/fXVJ/9ow1DB/LXugGkA/UDghb3v//SvtJls90rNGAzaN5nPFWKEiJGDKZUWSxyPKtASQcmRAinaiHFJeOCe8XDxmy0aHmMwLBg707mqIa3wynT5+wP3idzHo/z6WXYCRGqAlAC267oRQqe+PFuP0dZlHCXnRX+j1MlsOmy0e8N9EFpTC+WJy8+V69HD1aXgvgM0EFaxvyVo8UrTMNllGW5ztu0rdSSBuTcw3kUWWQBZBIk2m6KE6zNB0jl91tG7Ck21yTcJDBPQExdGYJd14lf6uZw87l/Ctla3gFZZvmOaNYzxO+vpn1Utx8JPc13fp4e1L3Q85eqVHL1H+5/pKfPSzcWZ9Ezmg92zkY5as0jECkhs/6BRRK4PCk5BpK78bDHUF/KRtKSLu4G82aiZicjXC9yQqJCSdqx4LJxfApHyh6qZmFAv048CYjQk6KonAdYSxEL42LluSC7ItzwvgP2CCa/hH2eEazjVFWyJcefTnYri1dQ4USEvT1iouRe7kFnHJu+Zi4WRuFU61IGzIvp/NcxsEYUuhRhcDGKFmtxRqB0or22HZeUXn/97yiu8JBhA2CKxOQoWP6nTEgdlAwRoTu3Cwn0JshwPq6XZTbofiwNqhbVrDAHYE9Z9MFHiqVcuXRZRHRWipUDJGhq1blG/y7DbolI0O33ph7arh++VpuMgoWAQu3wfjhTxsv9//uNv1uyizbcrMsd9Umfm7hRgm5pL8xEZ8/HqTYsAQ0bCLWWvOkqM4fETx9ySLCoecW378Bk7XjKQsT8v33szxNMnD6uarQFLQ0TFY1giWnESMsQ0pnOGDjp+/3t5djV7w5BznvKo5AjfWBlFaSxClVYhlfsldhZW/FsAXI16i3LOpmaEFKy4fT9IZf90AmmocXkuTE1dZERYh6tk0li9CvSwlvmvA0awNo20O/JrnOjsUrU3oDba6fEDwlIOtmokrikW9c7fRFYUPKIpUu43mwGTZGXR2Gz1WI3nq3EZXFETSEJFsCuZLRFKZSNFszIhiEBcnjlIYSHuXZ406L87l/et358U5plYwK0+2uXhx6rw419VpS1EFfUpLMdRsYm0pR48tBRdQOptSoB9T4TqMx3srJ5xKtXG4tiECa8cA5yYJFXnszkCrIOSdylP22DUTV9qC//F47FRoMlrG07TgDz12F5raXT1211eoZkTL/Ro8dkZeXzx2VSJFs+HKe+zvzi30LK0Ua7FQ/d5MfSpvWSHs6hHC0ETn4h1dbX0b8lumEBYFBy6RLjrPgJUkyCJXF+mi8vQSt3kP6s8LWKz4WgPWvnKX/ZZxpC8QkbA9Ti9ClGfsP4zOEiF1iQb5CNEsQ/b0yrXuWupgaobpuOrBUm95UgHMWJ7+oKXlqWcTk+WzUQIfdtF+F9OA7cgGHUnaxWSaYD4Y5tbngjsqwfWHb3sS1J04ninSEd/qNvb5Im/M949rTlhgTriy5gTsSNWcsLbPCQfsXATXS5gTojjCxbA4LsMCerKaLQvlGQgX70SC7fmmEBFtNdiiWVH8mDzvo1ffTpXuCIiSF8G/KYRaa1ca8Wa1q3FU2tUB+wYdiJW22tUF8sttmUm6r3Z1B+w4nuyN87T/S7xVJIIsp0/3z9WuhdunuTo7oq6O5fcDX4Isooup72ktyQGrb4HWgicDfvXtX0mOysQZlnZGcdr4fH89/JCFWDUX2Ttfvt5/3GISNJq+kGSdfBZlhYmwyPJ0NS5rEpF+yh6N4mwYx1f/oDQhtePIuZCUByQj0Qv2Suc2ev6Q/Ce+zdp9W7/f32SLtLJQ2lQyrGa5ljqGlhzgApc9GPBWhy3SUFABdMJtwEvjH2iJQoKhJ0w+rEjD8axHN4rnCXmwWVQ05TNSW/Se+CYlnB4JqfpbUPyY7mK5ilulptP9QSgwQSkxCSgJnqJFuZl+1FhNIt0eso1dYd3OsiLzbrBLADfM5RXsdzZ9ZeDeqMaWoaBS6jFoMRcEK0xDRDFlaiywdhtn7ywlwjYEBUhsQ1Nemguzlg2YT9baAeB6gpnUEpMiAuUlSIbEcgmL+863vO3olvwFZoUkycuVtxUUAVFW3jZQXjdh3VIq48n/5ugXc9n5okkGerhPK4j0kKFID9XpQxL0UEMLtc6P3rMyZCs9VM8JJlxFTRTleogrdt21IJrnQn9FmRqqtbTCBLC9V1YuFYWPOIRvg+ilaQq+CqDMfLaNE0sgUZsxQgMdrGF+XBkjLiylZnQtfAvtd79lBcG9A/jcE8PvSsElCs6xYG84OORvG8r3udyWNiCNwZynEJW27RDGIEzKwJ1C1JUhRHnf898/ODYdx2dtZFDb4CxtntqqPmRTi9t3FCLjdLzWEJlt7LlOn6T5LJkmizBWtlj/LjR7e1dHk2bn1F7X2sAO51upKw5s04c8oQhtjQzWENS0aY3nXtcKFVxPdaaiChworza5biHifXmJsMmNsFkc7rRG2ExLlhw5mgoE9Zzo5lAeKEd8WCG+80oP3EjH9ySzauCe+uSo0w73giKfdvjXar4EeG+nwBzhNw6Co7J3TIdNm78yu+7OdkCG2pWqb/hA18iSHJiw3FPKuX0r8NN6hGx1seMK48GvTjmdN7kA7JuGmk0uEPqOLXnTirvnRi610OfhqHP9rgn9aWF8thT7hgj51lEhHy7XdV3242vrK5L58JuQgez88z3XaLQDXxqIuzj6BwC/dakvTcCH9ZM7h3egFRIoEvkwV9KQvAxjKl9N/3yeiy8y9ylacLeqzk1otslvZR2RxG/AppNZfLGBkPADntqOgNgykuRss0Xlqb0mhIDSkzCb1VuiZMAT7pG0eYLVNobshG7bVJ5WWKDdQOVenSIt5/zEGUjI4cAhgNDmCQaU2oDGtrSIM9rxqe41PIw1ftCn9KCbPb1Bn25V37HXEIvKvozV/loE6d1qKBfUVC7pAbV1AfVG1njeUYCat7SPHtSe9aagFnnll1KPR6rVPZObZZoVu7QPZevLggBxkd3LmbSRWc4sZ6X01UtYcdeF2WVdS/e2rVPRJaBhiXapnRwKBDXEKnEpPxcGhLoGXtANBbCjAK41dkYBPkwTItjXl2OZO7tPJohc8X8=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -577,13 +577,13 @@
             <path d="M 410 450 L 405 450 Q 400 450 400 460 L 400 590 Q 400 600 395 600 L 392.5 600 Q 390 600 395 600 L 397.5 600 Q 400 600 400 610 L 400 740 Q 400 750 405 750 L 410 750" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,400,600)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="670" y="731" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="680" y="731" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 751px; margin-left: 671px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 751px; margin-left: 681px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -595,7 +595,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="730" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="740" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         MPK secret
                     </text>
                 </switch>
@@ -652,8 +652,8 @@
             </g>
         </g>
         <g>
-            <path d="M 105 671 L 105 691 L 590 691 L 590 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 590 729.88 L 586.5 722.88 L 590 724.63 L 593.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 105 671 L 105 691 L 600 691 L 600 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 600 729.88 L 596.5 722.88 L 600 724.63 L 603.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <path d="M 105 731 L 105 711 L 450 711 L 450 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
@@ -685,13 +685,13 @@
             </g>
         </g>
         <g>
-            <rect x="530" y="731" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="540" y="731" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 751px; margin-left: 531px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 751px; margin-left: 541px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -703,27 +703,27 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="590" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="600" y="755" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         DPK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 400 650 L 400 670 L 730 670 L 730 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 730 729.88 L 726.5 722.88 L 730 724.63 L 733.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 400 650 L 400 670 L 740 670 L 740 724.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 740 729.88 L 736.5 722.88 L 740 724.63 L 743.5 722.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 530 531 L 525 531 Q 520 531 520 541 L 520 800.52 Q 520 810.52 515 810.52 L 512.5 810.52 Q 510 810.52 515 810.52 L 517.5 810.52 Q 520 810.52 520 820.52 L 520 1080.05 Q 520 1090.05 525 1090.05 L 530 1090.05" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,520,810.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 534.47 725.54 L 529.47 725.54 Q 524.47 725.54 524.47 735.54 L 524.47 929.52 Q 524.47 939.52 519.47 939.52 L 516.97 939.52 Q 514.47 939.52 519.47 939.52 L 521.97 939.52 Q 524.47 939.52 524.47 949.52 L 524.47 1143.51 Q 524.47 1153.51 529.47 1153.51 L 534.47 1153.51" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,524.47,939.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="520" cy="841" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="520" cy="970" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 841px; margin-left: 461px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 970px; margin-left: 461px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Extract
@@ -731,7 +731,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="845" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="520" y="974" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Extract
                     </text>
                 </switch>
@@ -804,13 +804,13 @@
             </g>
         </g>
         <g>
-            <ellipse cx="610" cy="921" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="610" cy="1050" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 921px; margin-left: 551px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1050px; margin-left: 551px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Expand
@@ -818,15 +818,15 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="610" y="925" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="610" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Expand
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 430 941 L 430 964.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 430 969.88 L 426.5 962.88 L 430 964.63 L 433.5 962.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 430 1070 L 430 1093.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 430 1098.88 L 426.5 1091.88 L 430 1093.63 L 433.5 1091.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <rect x="740" y="120" width="90" height="20" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
@@ -854,13 +854,13 @@
             </g>
         </g>
         <g>
-            <rect x="700" y="901" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="700" y="1030" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 921px; margin-left: 701px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 1050px; margin-left: 701px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -872,24 +872,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="750" y="925" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="750" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         "derived_mek"
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 700 921 L 676.37 921" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 671.12 921 L 678.12 917.5 L 676.37 921 L 678.12 924.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 700 1050 L 676.37 1050" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 671.12 1050 L 678.12 1046.5 L 676.37 1050 L 678.12 1053.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="370" y="971" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="370" y="1100" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 991px; margin-left: 371px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1120px; margin-left: 371px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -906,24 +906,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="430" y="995" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="430" y="1124" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         MEK...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 520 861 L 520 881 L 430 881 L 430 894.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 430 899.88 L 426.5 892.88 L 430 894.63 L 433.5 892.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 520 990 L 520 1010 L 430 1010 L 430 1023.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 430 1028.88 L 426.5 1021.88 L 430 1023.63 L 433.5 1021.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="550" y="966" width="120" height="45" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="550" y="1095" width="120" height="45" fill="#ccffcc" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 204), rgb(0, 43, 0)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 989px; margin-left: 551px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1118px; margin-left: 551px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -935,20 +935,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="610" y="992" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="610" y="1121" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Derived MEK
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="490" y="906" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="490" y="1035" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 921px; margin-left: 491px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 1050px; margin-left: 491px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     OR
@@ -956,20 +956,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="520" y="925" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="520" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         OR
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <ellipse cx="430" cy="921" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="430" cy="1050" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 921px; margin-left: 371px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1050px; margin-left: 371px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     HKDF-Expand
@@ -977,28 +977,28 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="430" y="925" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="430" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         HKDF-Expand
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 520 861 L 520 881 L 610 881 L 610 894.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 610 899.88 L 606.5 892.88 L 610 894.63 L 613.5 892.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 520 990 L 520 1010 L 610 1010 L 610 1023.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 610 1028.88 L 606.5 1021.88 L 610 1023.63 L 613.5 1021.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <path d="M 610 941 L 610 959.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 610 964.88 L 606.5 957.88 L 610 959.63 L 613.5 957.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 610 1070 L 610 1088.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 610 1093.88 L 606.5 1086.88 L 610 1088.63 L 613.5 1086.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="240" y="901" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="240" y="1030" width="100" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 921px; margin-left: 241px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 1050px; margin-left: 241px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -1010,15 +1010,15 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="290" y="925" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="290" y="1054" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         "wrapped_mek"
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 340 921 L 363.63 921" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 368.88 921 L 361.88 924.5 L 363.63 921 L 361.88 917.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 340 1050 L 363.63 1050" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 368.88 1050 L 361.88 1053.5 L 363.63 1050 L 361.88 1046.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <path d="M 460 210 L 480 210 L 480 324.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
@@ -1084,6 +1084,112 @@
         </g>
         <g>
             <rect x="240" y="721" width="280" height="60" fill="none" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="320" y="880" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 900px; margin-left: 321px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    <div>
+                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                            EPK extraction
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="380" y="904" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        EPK extraction
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 389.22 658.78 L 384.22 658.78 Q 379.22 658.78 379.22 668.78 L 379.22 788.53 Q 379.22 798.53 374.22 798.53 L 371.72 798.53 Q 369.22 798.53 374.22 798.53 L 376.72 798.53 Q 379.22 798.53 379.22 808.53 L 379.22 928.28 Q 379.22 938.28 384.22 938.28 L 389.22 938.28" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,379.22,798.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <ellipse cx="380" cy="829" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 829px; margin-left: 321px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    HKDF-Extract
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="380" y="833" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        HKDF-Extract
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 679.22 658.78 L 674.22 658.78 Q 669.22 658.78 669.22 668.78 L 669.22 788.53 Q 669.22 798.53 664.22 798.53 L 661.72 798.53 Q 659.22 798.53 664.22 798.53 L 666.72 798.53 Q 669.22 798.53 669.22 808.53 L 669.22 928.28 Q 669.22 938.28 674.22 938.28 L 679.22 938.28" fill="none" stroke="#000000" stroke-miterlimit="10" transform="rotate(-90,669.22,798.53)" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <ellipse cx="670" cy="829" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 829px; margin-left: 611px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    HKDF-Extract
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="670" y="833" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        HKDF-Extract
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="609.22" y="880" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 900px; margin-left: 610px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    <div>
+                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                            MPK secret
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="669" y="904" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        MPK secret
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 380 849 L 380 873.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 380 878.88 L 376.5 871.88 L 380 873.63 L 383.5 871.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 670 849 L 669.38 873.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 669.25 878.88 L 665.93 871.8 L 669.38 873.63 L 672.92 871.97 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
     </g>
     <switch>

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -327,11 +327,17 @@ KMB can encrypt randomly-generated MEKs, or compute derived MEKs.
 
 ![MEK generation](./diagrams/mek_generation.drawio.svg){#fig:mek-generation}
 
+^1^ see @fig:mek-secret-derivation for details
+
 ![MEK loading](./diagrams/mek_loading.drawio.svg){#fig:mek-loading}
+
+^1^ see @fig:mek-secret-derivation for details
 
 #### Deriving an MEK
 
 ![MEK derivation](./diagrams/mek_derivation.drawio.svg){#fig:mek-derivation}
+
+^1^ see @fig:mek-secret-derivation for details
 
 #### MEK secret derivation {#sec:mek-secret-derivation}
 


### PR DESCRIPTION
HW may not be able to support mixing FW provided data and KV slot data in the same HMAC operation for an HKDF. This change solves this problem by doing an HKDF of the FW provided data (SEK and HEK) then putting it in another KV slot. Separately the KV slot data separately is HKDF'ed together. Then the output of both HKDFs is then HKDF'ed together because they will all be in KV slots at that point.

This also clarifies in the other MEK diagrams how to find the design details for MEK secret derivation.