### PR TITLE
Add TEST_ACCESS_KEY command.

### DIFF
--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -932,30 +932,30 @@ Table: ROTATE_ENCAPSULATION_KEY output arguments
 
 #### GENERATE_MPK
 
-This command unwraps the specified access key, generates a random MPK, then uses the HEK and access key to encrypt the MPK which is returned for the drive to persistently store. The given \`uid\` is placed in the  \`aad\` field of the returned MPK to cryptographically tie the UID to the MPK.
+This command unwraps the specified access key, generates a random MPK, then uses the HEK and access key to encrypt the MPK which is returned for the drive to persistently store. The given \`metadata\` is placed in the  \`metadata\` field of the returned MPK to cryptographically tie them together.
 
 Command Code: 0x474D_504B ("GMPK")
 
 Table: GENERATE_MPK input arguments
 
-+-------------------+-----------------+----------------------------------------+
-| Name              | Type            | Description                            |
-+===================+=================+========================================+
-| chksum            | u32             | Checksum over other input arguments,   |
-|                   |                 | computed by the caller.                |
-+-------------------+-----------------+----------------------------------------+
-| reserved          | u32             | Reserved.                              |
-+-------------------+-----------------+----------------------------------------+
-| uid_len           | u32             | Length of the uid argument.            |
-+-------------------+-----------------+----------------------------------------+
-| info_len          | u32             | Length of the info argument.           |
-+-------------------+-----------------+----------------------------------------+
-| uid               | u8[uid_len]     | Unique identifier for the MPK.         |
-+-------------------+-----------------+----------------------------------------+
-| info              | u8[info_len]    | Info argument to use with HPKE unwrap. |
-+-------------------+-----------------+----------------------------------------+
-| sealed_access_key | SealedAccessKey | HPKE-sealed access key.                |
-+-------------------+-----------------+----------------------------------------+
++-------------------+------------------+----------------------------------------+
+| Name              | Type             | Description                            |
++===================+==================+========================================+
+| chksum            | u32              | Checksum over other input arguments,   |
+|                   |                  | computed by the caller.                |
++-------------------+------------------+----------------------------------------+
+| reserved          | u32              | Reserved.                              |
++-------------------+------------------+----------------------------------------+
+| metadata_len      | u32              | Length of the metadata argument.       |
++-------------------+------------------+----------------------------------------+
+| info_len          | u32              | Length of the info argument.           |
++-------------------+------------------+----------------------------------------+
+| metadata          | u8[metadata_len] | Unique identifier for the MPK.         |
++-------------------+------------------+----------------------------------------+
+| info              | u8[info_len]     | Info argument to use with HPKE unwrap. |
++-------------------+------------------+----------------------------------------+
+| sealed_access_key | SealedAccessKey  | HPKE-sealed access key.                |
++-------------------+------------------+----------------------------------------+
 
 Table: GENERATE_MPK output arguments
 
@@ -1106,7 +1106,7 @@ Table: MIX_MPK output arguments
 
 #### TEST_ACCESS_KEY
 
-This command is used by the host to check the correct access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as SHA2-384(UID || decrypted access key || nonce). The UID is taken from the provided MPK's \`aad\` field.
+This command is used by the host to check the correct access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as SHA2-384(metadata || decrypted access key || nonce). The metadata is taken from the provided MPK's \`metadata\` field.
 
 Command Code: 0x5441_434B ("TACK")
 
@@ -1128,8 +1128,8 @@ Table: TEST_ACCESS_KEY output arguments
 +--------+--------+------------------------------------------------------+
 | Name   | Type   | Description                                          |
 +========+========+======================================================+
-| digest | u8[48] | SHA-384 hash of the MPK's UID, decrypted access key, |
-|        |        | and nonce.                                           |
+| digest | u8[48] | SHA-384 hash of the MPK's metadata, decrypted access |
+|        |        | key, and nonce.                                      |
 +--------+--------+------------------------------------------------------+
 
 #### GENERATE_MEK
@@ -1616,31 +1616,31 @@ AES-256-GCM is used for all wrapping and unwrapping.
 
 Table: WrappedKey contents
 
-+----------+-------------+--------------------------------------------+
-| Name     | Type        | Description                                |
-+==========+=============+============================================+
-| key_type | u16         | Type of the wrapped key. This is treated   |
-|          |             | as AAD when the key is decrypted.          |
-|          |             |                                            |
-|          |             | - 0h: Reserved                             |
-|          |             | - 1h: LOCKED_MPK (ciphertext held at rest) |
-|          |             | - 2h: READY_MPK (ciphertext held in RAM)   |
-|          |             | - 3h: WRAPPED_MEK                          |
-|          |             | - 4h to FFFFh: Reserved                    |
-+----------+-------------+--------------------------------------------+
-| reserved | u16         | Reserved.                                  |
-+----------+-------------+--------------------------------------------+
-| aad_len  | u32         | Length of the aad field.                   |
-+----------+-------------+--------------------------------------------+
-| ct_len   | u32         | Length of the ct field.                    |
-+----------+-------------+--------------------------------------------+
-| iv       | u8[12]      | Initialization vector for AES operation.   |
-+----------+-------------+--------------------------------------------+
-| aad      | u8[aad_len] | Additional authenticated data to be added  |
-|          |             | to the GCM tag calculation.                |
-+----------+-------------+--------------------------------------------+
-| ct       | u8[ct_len]  | Key ciphertext and authentication tag.     |
-+----------+-------------+--------------------------------------------+
++--------------+------------------+--------------------------------------------+
+| Name         | Type             | Description                                |
++==============+==================+============================================+
+| key_type     | u16              | Type of the wrapped key. This is treated   |
+|              |                  | as AAD when the key is decrypted.          |
+|              |                  |                                            |
+|              |                  | - 0h: Reserved                             |
+|              |                  | - 1h: LOCKED_MPK (ciphertext held at rest) |
+|              |                  | - 2h: READY_MPK (ciphertext held in RAM)   |
+|              |                  | - 3h: WRAPPED_MEK                          |
+|              |                  | - 4h to FFFFh: Reserved                    |
++--------------+------------------+--------------------------------------------+
+| reserved     | u16              | Reserved.                                  |
++--------------+------------------+--------------------------------------------+
+| metadata_len | u32              | Length of the metadata field.              |
++--------------+------------------+--------------------------------------------+
+| ct_len       | u32              | Length of the ct field.                    |
++--------------+------------------+--------------------------------------------+
+| iv           | u8[12]           | Initialization vector for AES operation.   |
++--------------+------------------+--------------------------------------------+
+| metadata     | u8[metadata_len] | Additional authenticated data to be added  |
+|              |                  | to the GCM tag calculation.                |
++--------------+------------------+--------------------------------------------+
+| ct           | u8[ct_len]       | Key ciphertext and authentication tag.     |
++--------------+------------------+--------------------------------------------+
 
 Variants of WrappedKey will be used to reduce duplicating information in commands. The following names will be used for WrappedKeys of a specific \`key_type\` and \`ct_len\`:
 

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -932,7 +932,7 @@ Table: ROTATE_ENCAPSULATION_KEY output arguments
 
 #### GENERATE_MPK
 
-This command unwraps the specified access key, generates a random MPK, then uses the HEK and access key to encrypt the MPK which is returned for the drive to persistently store.
+This command unwraps the specified access key, generates a random MPK, then uses the HEK and access key to encrypt the MPK which is returned for the drive to persistently store. The given \`uid\` is placed in the  \`aad\` field of the returned MPK to cryptographically tie the UID to the MPK.
 
 Command Code: 0x474D_504B ("GMPK")
 
@@ -946,7 +946,11 @@ Table: GENERATE_MPK input arguments
 +-------------------+-----------------+----------------------------------------+
 | reserved          | u32             | Reserved.                              |
 +-------------------+-----------------+----------------------------------------+
+| uid_len           | u32             | Length of the uid argument.            |
++-------------------+-----------------+----------------------------------------+
 | info_len          | u32             | Length of the info argument.           |
++-------------------+-----------------+----------------------------------------+
+| uid               | u8[uid_len]     | Unique identifier for the MPK.         |
 +-------------------+-----------------+----------------------------------------+
 | info              | u8[info_len]    | Info argument to use with HPKE unwrap. |
 +-------------------+-----------------+----------------------------------------+
@@ -1099,6 +1103,34 @@ Table: MIX_MPK output arguments
 +-------------+------+-------------------------------------------+
 | reserved    | u32  | Reserved.                                 |
 +-------------+------+-------------------------------------------+
+
+#### TEST_ACCESS_KEY
+
+This command is used by the host to check the correct access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as Sha384(UID || decrypted access key || nonce). The UID is taken from the provided MPK's \`aad\` field.
+
+Command Code: 0x5441_434B ("TACK")
+
+Table: TEST_ACCESS_KEY input arguments
+
++-------------------+-----------------+---------------------------------------+
+| Name              | Type            | Description                           |
++===================+=================+=======================================+
+| nonce             | u8[32]          | Host provided random value            |
++-------------------+-----------------+---------------------------------------+
+| locked_mpk        | LockedMpk       | Locked MPK associated with the access |
+|                   |                 | key                                   |
++-------------------+-----------------+---------------------------------------+
+| sealed_access_key | SealedAccessKey | HPKE-sealed access key.               |
++-------------------+-----------------+---------------------------------------+
+
+Table: TEST_ACCESS_KEY output arguments
+
++--------+--------+------------------------------------------------------+
+| Name   | Type   | Description                                          |
++========+========+======================================================+
+| digest | u8[48] | SHA-384 hash of the MPK's UID, decrypted access key, |
+|        |        | and nonce.                                           |
++--------+--------+------------------------------------------------------+
 
 #### GENERATE_MEK
 
@@ -1584,24 +1616,31 @@ AES-256-GCM is used for all wrapping and unwrapping.
 
 Table: WrappedKey contents
 
-+----------+------------+--------------------------------------------+
-| Name     | Type       | Description                                |
-+==========+============+============================================+
-| key_type | u16        | Type of the wrapped key. This is treated   |
-|          |            | as AAD when the key is decrypted.          |
-|          |            |                                            |
-|          |            | - 0h: Reserved                             |
-|          |            | - 1h: LOCKED_MPK (ciphertext held at rest) |
-|          |            | - 2h: READY_MPK (ciphertext held in RAM)   |
-|          |            | - 3h: WRAPPED_MEK                          |
-|          |            | - 4h to FFFFh: Reserved                    |
-+----------+------------+--------------------------------------------+
-| ct_len   | u16        | Length of the ciphertext and tag in bytes. |
-+----------+------------+--------------------------------------------+
-| iv       | u8[12]     | Initialization vector for AES operation.   |
-+----------+------------+--------------------------------------------+
-| ct       | u8[ct_len] | Key ciphertext and authentication tag.     |
-+----------+------------+--------------------------------------------+
++----------+-------------+--------------------------------------------+
+| Name     | Type        | Description                                |
++==========+=============+============================================+
+| key_type | u16         | Type of the wrapped key. This is treated   |
+|          |             | as AAD when the key is decrypted.          |
+|          |             |                                            |
+|          |             | - 0h: Reserved                             |
+|          |             | - 1h: LOCKED_MPK (ciphertext held at rest) |
+|          |             | - 2h: READY_MPK (ciphertext held in RAM)   |
+|          |             | - 3h: WRAPPED_MEK                          |
+|          |             | - 4h to FFFFh: Reserved                    |
++----------+-------------+--------------------------------------------+
+| reserved | u16         | Reserved.                                  |
++----------+-------------+--------------------------------------------+
+| aad_len  | u32         | Length of the aad field.                   |
++----------+-------------+--------------------------------------------+
+| ct_len   | u32         | Length of the ct field.                    |
++----------+-------------+--------------------------------------------+
+| iv       | u8[12]      | Initialization vector for AES operation.   |
++----------+-------------+--------------------------------------------+
+| aad      | u8[aad_len] | Additional authenticated data to be added  |
+|          |             | to the GCM tag calculation.                |
++----------+-------------+--------------------------------------------+
+| ct       | u8[ct_len]  | Key ciphertext and authentication tag.     |
++----------+-------------+--------------------------------------------+
 
 Variants of WrappedKey will be used to reduce duplicating information in commands. The following names will be used for WrappedKeys of a specific \`key_type\` and \`ct_len\`:
 

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -1106,7 +1106,7 @@ Table: MIX_MPK output arguments
 
 #### TEST_ACCESS_KEY
 
-This command is used by the host to check the correct access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as Sha384(UID || decrypted access key || nonce). The UID is taken from the provided MPK's \`aad\` field.
+This command is used by the host to check the correct access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as SHA2-384(UID || decrypted access key || nonce). The UID is taken from the provided MPK's \`aad\` field.
 
 Command Code: 0x5441_434B ("TACK")
 
@@ -1115,10 +1115,10 @@ Table: TEST_ACCESS_KEY input arguments
 +-------------------+-----------------+---------------------------------------+
 | Name              | Type            | Description                           |
 +===================+=================+=======================================+
-| nonce             | u8[32]          | Host provided random value            |
+| nonce             | u8[32]          | Host provided random value.           |
 +-------------------+-----------------+---------------------------------------+
 | locked_mpk        | LockedMpk       | Locked MPK associated with the access |
-|                   |                 | key                                   |
+|                   |                 | key.                                  |
 +-------------------+-----------------+---------------------------------------+
 | sealed_access_key | SealedAccessKey | HPKE-sealed access key.               |
 +-------------------+-----------------+---------------------------------------+

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -932,7 +932,7 @@ Table: ROTATE_ENCAPSULATION_KEY output arguments
 
 #### GENERATE_MPK
 
-This command unwraps the specified access key, generates a random MPK, then uses the HEK and access key to encrypt the MPK which is returned for the drive to persistently store. The given \`metadata\` is placed in the  \`metadata\` field of the returned MPK to cryptographically tie them together.
+This command unwraps the specified access key, generates a random MPK, then uses the HEK and access key to encrypt the MPK which is returned for the drive to persistently store. The given \`metadata\` is placed in the  \`metadata\` field of the returned MPK to cryptographically tie them together. Note that "metadata" in this context refers to metadata about the MPK, and bears no relation to metadata about an MEK.
 
 Command Code: 0x474D_504B ("GMPK")
 

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -950,7 +950,7 @@ Table: GENERATE_MPK input arguments
 +-------------------+------------------+----------------------------------------+
 | info_len          | u32              | Length of the info argument.           |
 +-------------------+------------------+----------------------------------------+
-| metadata          | u8[metadata_len] | Unique identifier for the MPK.         |
+| metadata          | u8[metadata_len] | Metadata for the MPK.                  |
 +-------------------+------------------+----------------------------------------+
 | info              | u8[info_len]     | Info argument to use with HPKE unwrap. |
 +-------------------+------------------+----------------------------------------+
@@ -1106,7 +1106,7 @@ Table: MIX_MPK output arguments
 
 #### TEST_ACCESS_KEY
 
-This command is used by the host to check the correct access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as SHA2-384(metadata || decrypted access key || nonce). The metadata is taken from the provided MPK's \`metadata\` field.
+This command is used by the host to check the input access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as SHA2-384(metadata || decrypted access key || nonce). The metadata is taken from the provided MPK's \`metadata\` field.
 
 Command Code: 0x5441_434B ("TACK")
 
@@ -1619,8 +1619,7 @@ Table: WrappedKey contents
 +--------------+------------------+--------------------------------------------+
 | Name         | Type             | Description                                |
 +==============+==================+============================================+
-| key_type     | u16              | Type of the wrapped key. This is treated   |
-|              |                  | as AAD when the key is decrypted.          |
+| key_type     | u16              | Type of the wrapped key.                   |
 |              |                  |                                            |
 |              |                  | - 0h: Reserved                             |
 |              |                  | - 1h: LOCKED_MPK (ciphertext held at rest) |
@@ -1636,11 +1635,12 @@ Table: WrappedKey contents
 +--------------+------------------+--------------------------------------------+
 | iv           | u8[12]           | Initialization vector for AES operation.   |
 +--------------+------------------+--------------------------------------------+
-| metadata     | u8[metadata_len] | Additional authenticated data to be added  |
-|              |                  | to the GCM tag calculation.                |
+| metadata     | u8[metadata_len] | Metadata associated with the wrapped key.  |
 +--------------+------------------+--------------------------------------------+
 | ct           | u8[ct_len]       | Key ciphertext and authentication tag.     |
 +--------------+------------------+--------------------------------------------+
+
+The AAD for the encrypted message is constructed as \`key_type\` || \`metadata_len\` || \`metadata\`.
 
 Variants of WrappedKey will be used to reduce duplicating information in commands. The following names will be used for WrappedKeys of a specific \`key_type\` and \`ct_len\`:
 


### PR DESCRIPTION
This command is used by the host to verify the correct access key is associated with a given AccessConditions object UID from an MPK.

This change also adds the UID to MPKs as additional authenticated data to ensure the MPK is tied cryptographically to the correct UID.