### PR TITLE
Add a sequence diagram for the TEST_ACCESS_KEY command.

### DIFF
--- a/doc/ocp_lock/diagrams/uml/test_access_key.uml
+++ b/doc/ocp_lock/diagrams/uml/test_access_key.uml
@@ -1,0 +1,37 @@
+'
+' OCP Lock: TEST_ACCESS_KEY API sequence diagram showing Caliptra FW/HW interactions
+'
+'
+@startuml
+
+!include ocp_lock_utils.inc
+
+' Pre-existing state
+hek++ $BUFFER_ACTIVATION
+kemg++ $BUFFER_ACTIVATION
+
+fw $async mb++ : TEST_ACCESS_KEY
+
+mb $async cfw++ : Command
+mb--
+
+cfw $sync kv++: Decaps(KEM Pair : kem_handle (G),\n             KEM ciphertext : kem_ciphertext\n             Destination : Slot Y)
+kv $sync kemg: Get KEM Keypair
+kv $sync kv: Decap KEM Ciphertext with Keypair
+kv $sync tempy: Put Shared Secret
+tempy++ $BUFFER_ACTIVATION
+kv $sync cfw-- : done
+
+cfw $sync kv++: Key_Unwrap(Key : Slot Y,\n                   Data: encrypted_access_key\n                   Destination : Slot Z)
+kv $sync tempy: Get Shared Secret
+kv $sync kv: Key_Unwrap encrypted_access_key with Key
+kv $sync cfw-- : unwrapped access_key
+cfw $sync cfw : SHA384(Data: metadata,\n              Data: decrypted access key,\n              Data: nonce)
+
+cfw $sync mb : Command response\nproof of possession digest
+& mb $async fw++ : Command\ncomplete
+
+cfw--
+kv--
+
+@enduml

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -1159,6 +1159,8 @@ Table: MIX_MPK output arguments
 
 This command is used by the host to check the input access key is associated with the given MPK. The \`nonce\` is a random value to be included in the digest calculation to prevent response replay attacks. The output is calculated as SHA2-384(metadata || decrypted access key || nonce). The metadata is taken from the provided MPK's \`metadata\` field.
 
+See @fig:test-access-key-uml for the sequence diagram.
+
 Command Code: 0x5441_434B ("TACK")
 
 Table: TEST_ACCESS_KEY input arguments
@@ -1961,6 +1963,12 @@ This section will be fleshed out with additional details as they become availabl
 
 ```plantuml {caption="UML: Mixing an MPK" #fig:mix-mpk-uml}
 !include diagrams/uml/mix_mpk.uml
+```
+
+## Sequence to test the access key of an MPK
+
+```plantuml {caption="UML: Testing an Access Key" #fig:test-access-key-uml}
+!include diagrams/uml/test_access_key.uml
 ```
 
 ## Sequence to load an MEK


### PR DESCRIPTION
Document the TEST_ACCESS_KEY command flow with a sequence diagram similar to other commands.