### PR TITLE
Forward the location hash to the PDF viewer.

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -100,7 +100,11 @@ jobs:
               cat > "${pdf_dir_name}/index.html" << EOF
                 <html>
                   <body style="margin:0">
-                    <iframe style="border:none" width="100%" height="100%" src="${pdf_name}"></iframe>
+                    <iframe id="viewer" style="border:none" width="100%" height="100%"></iframe>
+                    <script type="text/javascript">
+                      # Forward the location hash to the iframe to allow deep-linking.
+                      document.getElementById("viewer").src = "${pdf_name}" + document.location.hash;
+                    </script>
                   </body>
                 </html>
           EOF


### PR DESCRIPTION
Allows deep-linking.