### PR TITLE
Update call details

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,10 @@ and published security advisories, refer to
 
 ## Discussion Channels
 
-The Caliptra workgroup meets every Friday at 9am PT. Meeting invite and agenda
+The Caliptra workgroup meets every Thursday at 1pm PT. Meeting invite and agenda
 are posted to the [mailing list](https://lists.chipsalliance.org/g/caliptra-wg).
 The [call
-invite](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTViMGQ5MDYtNGY4MS00ODY5LTg4NmQtNDE3N2QwZmVhMmNh%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%22661ec88e-77cb-431c-935a-b377b1078af4%22%7d)
-is also reachable from the [CHIPS Workgroups
+invite](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MmQwYTE4YzQtOWJkMy00YzcyLTgxMDUtYTQ2Zjk2ZjhkMzk5%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%22661ec88e-77cb-431c-935a-b377b1078af4%22%7d) is also reachable from the [CHIPS Workgroups
 page](https://www.chipsalliance.org/workgroups/).
 
 A [Slack channel](https://join.slack.com/t/caliptraworkspace/signup)


### PR DESCRIPTION
I pulled the current call link from my calendar. I note that the link on my calendar is different from the link on https://www.chipsalliance.org/workgroups/.