### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/doc/ocp_lock/diagrams/preconditioned_aes_decrypt.drawio.svg
+++ b/doc/ocp_lock/diagrams/preconditioned_aes_decrypt.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="461px" viewBox="-0.5 -0.5 831 461" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VxbU+M2FP41eWTHdyePIRfa6e6UGTrt8ihi4ag4ViorkPTXV7Il3+QEJ5FNSoAZxjq2ZOmc71wlM7Anq+0dAevlDxzAaGAZwXZgTweWNfRH7C8n7DKC61kZISQoyEhmQXhA/0JBNAR1gwKYVB6kGEcUravEBY5juKAVGiAEv4nHxHDPOKq+dQ1CqBAeFiBSqX+hgC7FslyjoP8CUbiUbzYNcecJLF5CgjexeN/Asp/Tn+z2CsixxPPJEgT4rUSyZwN7QjCm2dVqO4ERZ61kW9ZvvuduPm8CY9qqg5TUK4g2YvFTgl4h5xoiqzc2kpgp3UnupOuDfARjYN++LRGFD2uw4HffGBwYbUlXEWuZ7PIZRdEER5ikfe35mP8yekIJfoGlO0b6w+6ACIUxo0Xwma3h9hUSiphoxoJMMX9Dwl6I4vB7+szUZxR16YIbfAC4LZEEK+4gXkFKduyRbRV+u2rzrYBATluWxO94gggE7MJ85IL17EJwf58kbEUSA8uLOAsC9MouQ5quMiM9Y7ZKrgCSf94/G5w9IDlZImV9pxsCniIo35HIsdjUsuGqr2DkyovPQYGU6YIJB5IGqa5QEPCRb3ON4KOGEUgScV2VeIlyiynFqyrtDw6SlFDD38ydTOZzwUBheExDD3x8t4ofR8XPqAE+lhb0uAp6vsMQMjtUlxtbDFX0L8YxbBJTmXvimZJU9wqxCQ1VvHTBfs99T329BvbbOtg/crpW3tl6CVeQgOiq1Zcrb1/q6/envrZ8dUlAMGAhiWhiQpc4xDGIZgW1LCC4RfRn6fqRs++bK1rTreBm2tjJRsxm+bPcKPXizaJb2pL9qsjZy/gEb8hCrMU2hyKKAySEUvEcEXvwlR4UEIERoDwoqcR5DfxOu44JAbvSA2uMYpqURr7nhELuuZ2WZtusxUzvPC+FV8g6m0Eh+Xwp7cAgmdWhMYkXZLemTIjH2RCtk1jBJOFx+BWasTwKCQkIEJtNzcfuD45lhykiLPFBmM+aaRo3UDpsoFt1ofZItYGm1RQC6zCCppqLKPL+H9k8x2qweZbfic1TjJTjVyU5rAkom6nodMDY1ccxzdpA2eqUgU6xe9Ynd4JS9lVAmLoB0VrfcvPQmZ+5jwDDBU84rtDI57FqAJJlOntTk5H2qgFIU6TanZVuMMo9ammhmI9yjNZautiQ12NV1u7FhrdnfudFopF384R4r1//vGql1aCnVk1P+42mLO9ze1PHuTDV9BXVHM8ebu4mPxo0dArTBKylKrE3oXWyr7B2oNg+1wdmx/pQp9OUEh+NbhgHY747xA0NtxxoUWVfFYbsaVFh8tKUDBBaap8K9VPUqp1CNNdYnJYKURKj2yBFSTszLcmrrdIk1tHRNi+xa3A062XcPXlJ38UhuWBtxSGrRZJc1gS1ai8RWKDusXTnuADMeAft7ZBrN2XKUqBdZ8quUUOSa3zzLaP4sU9DqDKuf3hcjYm0ZF13USLLQUSYyHwc+/sCd1/RomYH27B/1Z2DtZtqAR/rYKWZ0pAnajJTTcmgtF0X4mD9+hkGU481c4bHjavTmlkKNB/uWXtoGDemwYIe47fpXAXrBcbMpturSqu1gsxYJyz5gPSzmeCuq2y9Ju+217UH9xxZ55l+eW69dZ6e1fzIhKA/z91H5ail5/Yu33PbtdT41B07c1jbsasfUNHomiWAT64xaqkXVur6PddXZEG+6yy1Xjhx6vWO1oWT+kAt4bG/cHIWgMxLAFDfNbm2hueyzz3JiKixtKX2rp2us/12AD4JVWrGcCB6YqFCXIGgDJWKw/w3IrQac1ESECdS7rdqYGVaQxFZURCWYqjsNV+h1VmhVb+7Do59pnXqsdJ6yhaadAUfckLJ07UV4NYti9FhwNP5Oe8JWi9T9bjuMzNd2I5eC6qO+kHGCcbkCncsZa52IWmZctq7ZdyiDlSroOYTvLAdS9PXvGPpaDqIctJGgHkc1k86iNJ0rLN1ceHc3cs90uvE+aknXDQ7v9/X/Eh7+o3TAouDoww3hLmMa/SGsyn/HXRf2+63Yul0/n3LBMfM+6X9rvdbuRw9PXwrl38A38vHcucWjT7sZOPfm9VaTjNMgdPSxYwaXIyrvfTYXgKnxLJnSuBQzbfImfmuZ0VAI//d+Ja37iFBjA9cYY9x/U1y6e0Tn3pk2mWhv2mTqa+K2ng8/aqjaT6Kbvfp8N3Ov1ooBY5seiAAFFyjy+/tMESX+GHN4h/gZMaq+CdD9uw/&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="461px" viewBox="-0.5 -0.5 831 461" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VxbU+M2FP41eWTHdyePIRfa6e6UGTrt8ihi4ag4ViorkPTXV7Il3+QEJ5FNSoAZxjq2ZOmc71wlM7Anq+0dAevlDxzAaGAZwXZgTweWNfRH7C8n7DKC61kZISQoyEhmQXhA/0JBNAR1gwKYVB6kGEcUravEBY5juKAVGiAEv4nHxHDPOKq+dQ1CqBAeFiBSqX+hgC7FslyjoP8CUbiUbzYNcecJLF5CgjexeN/Asp/Tn+z2CsixxPPJEgT4rUSyZwN7QjCm2dVqO4ERZ61kW9ZvvuduPm8CY9qqg5TUK4g2YvFTgl4h5xoiqzc2kpgp3UnupOuDfARjYN++LRGFD2uw4HffGBwYbUlXEWuZ7PIZRdEER5ikfe35mP8yekIJfoGlO0b6w+6ACIUxo0Xwma3h9hUSiphoxoJMMX9Dwl6I4vB7+szUZxR16YIbfAC4LZEEK+4gXkFKduyRbRV+u2rzrYBATluWxO94gggE7MJ85IL17EJwf58kbEUSA8uLOAsC9MouQ5quMiM9Y7ZKrgCSf94/G5w9IDlZImV9pxsCniIo35HIsdjUsuGqr2DkyovPQYGU6YIJB5IGqa5QEPCRb3ON4KOGEUgScV2VeIlyiynFqyrtDw6SlFDD38ydTOZzwUBheExDD3x8t4ofR8XPqAE+lhb0uAp6vsMQMjtUlxtbDFX0L8YxbBJTmXvimZJU9wqxCQ1VvHTBfs99T329BvbbOtg/crpW3tl6CVeQgOiq1Zcrb1/q6/envrZ8dUlAMGAhiWhiQpc4xDGIZgW1LCC4RfRn6fqRs++bK1rTreBm2tjJRsxm+bPcKPXizaJb2pL9qsjZy/gEb8hCrMU2hyKKAySEUvEcEXvwlR4UEIERoDwoqcR5DfxOu44JAbvSA2uMYpqURr7nhELuuZ2WZtusxUzvPC+FV8g6m0Eh+Xwp7cAgmdWhMYkXZLemTIjH2RCtk1jBJOFx+BWasTwKCQkIEJtNzcfuD45lhykiLPFBmM+aaRo3UDpsoFt1ofZItYGm1RQC6zCCppqLKPL+H9k8x2qweZbfic1TjJTjVyU5rAkom6nodMDY1ccxzdpA2eqUgU6xe9Ynd4JS9lVAmLoB0VrfcvPQmZ+5jwDDBU84rtDI57FqAJJlOntTk5H2qgFIU6TanZVuMMo9ammhmI9yjNZautiQ12NV1u7FhrdnfudFopF384R4r1//vGql1aCnVk1P+42mLO9ze1PHuTDV9BXVHM8ebu4mPxo0dArTBKylKrE3oXWyr7B2oNg+1wdmx/pQp9OUEh+NbhgHY747xA0NtxxoUWVfFYbsaVFh8tKUDBBaap8K9VPUqp1CNNdYnJYKURKj2yBFSTszLcmrrdIk1tHRNi+xa3A062XcPXlJ38UhuWBtxSGrRZJc1gS1ai8RWKDusXTnuADMeAft7ZBrN2XKUqBdZ8quUUOSa3zzLaP4sU9DqDKuf3hcjYm0ZF13USLLQUSYyHwc+/sCd1/RomYH27B/1Z2DtZtqAR/rYKWZ0pAnajJTTcmgtF0X4mD9+hkGU481c4bHjavTmlkKNB/uWXtoGDemwYIe47fpXAXrBcbMpturSqu1gsxYJyz5gPSzmeCuq2y9Ju+217UH9xzhwBMQXXd5VgNW6pWenhX9yJSgP9/dR+2ope/2Lt9327Xk+NQ9O3NY27OrH1HR6JwlgE+uMmqpGFYq+z1XWGRJvus8tV46ceoVj9alk/pALeGxv3RyFoDMSwBQ31W5tobnsk8+yZiosbil9q6dr7P9dgA+CVVqznAgfmKhQlyBoAyWiuP8NyK4GnNREhAnUu63amhlWkMRW1EQlmKo7DVfodVZoVW/+w6OfaZ16rHWesommnQFH3JGydO1GeDWLYvRYcDT+UnvCVovU/X4Sst0245eS6qO+knGCcbkCvcsZa52IWmZct67ZdyiDlSroeYTvLA9S9PXvGfpaDqKctJWgHkc1k86itJ0sLN1ceHc/cs90uvE+alnXDQ7v7SUb0TgiX9QfH3ebzblv4Puq9n9Viidzr9omeCYebu03/V+HZejp4ev4/JP3nv5PO7cItGHnWX8e7Nay2mGKXBaupRRg0txtZca20vglNj1TAkcqvEWOTLf56wIaOS/G8/y1j0kiPGBK+wxrr5JLr191FOPRLss7DdtKvVVQRuPp191M82Hz+0+Hb7b+XcKv6/514/p5/BseiAAFFyjy+/t+EOX+GHN4l/eZMaq+LdC9uw/&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -309,7 +309,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            64-bit ID
+                                            64-bit salt
                                         </font>
                                     </div>
                                 </div>
@@ -317,7 +317,7 @@
                         </div>
                     </foreignObject>
                     <text x="310" y="164" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        64-bit ID
+                        64-bit salt
                     </text>
                 </switch>
             </g>
@@ -408,7 +408,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            Optional context string
+                                            KDF label
                                         </font>
                                     </div>
                                 </div>
@@ -416,7 +416,7 @@
                         </div>
                     </foreignObject>
                     <text x="610" y="164" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Optional context str...
+                        KDF label
                     </text>
                 </switch>
             </g>

--- a/doc/ocp_lock/diagrams/preconditioned_aes_encrypt.drawio.svg
+++ b/doc/ocp_lock/diagrams/preconditioned_aes_encrypt.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="481px" viewBox="-0.5 -0.5 831 481" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7Vxbc6M2FP41nmkfkgFkbo+OnaSd7k4zTafdfeoooGC6GFxZTuz++pVAwiDkLMaCOHGcmV04SELS+c5d9ghMF5tbDJfzz1mIkpFlhJsRmI0sy3N9+i8jbAuC7VgFIcJxWJDMHeE+/h9xosGp6zhEq1pDkmUJiZd1YpClKQpIjQYxzp55Mz7cY5bU37qEEWoQ7gOYNKl/xyGZ82XZxo7+C4qjuXizafAnDzD4FuFsnfL3jSzwmH+KxwsoxuLtV3MYZs8VErgegSnOMlJcLTZTlLCtFdtW9LvZ87ScN0YpadVBcOoJJmu++BmOnxDbtRgvnulIfKZkK3YnXx9iIxgjcPU8jwm6X8KAPX2mcKC0OVkk9M6kl49xkkyzJMN5X3AzYX+UviI4+4YqT4z8Q5/AJI5SSkvQI13D1RPCJKasmXAyydgbVvSFcRp9ytvMXEppLp3vBhsAbSokvhW3KFsggre0yaYOv2399nkHgZI2r7B/7HAi5LCLypF3W08v+O6rOWGNjQYnGjtf2Ve0ickXzgJ2/ZVdX9r8brapPJptxU1KJ/VFDMBuKr3Y7a5bfif61Rm+d6NX2RoHfKaW43C5hThCvJ3ljwsiCmvy12QIRgkkDIY1yVZsL+96l8V0MiUjx65d56QpcaiYKu9VlY8fDORJ4xSra4yTM7tcTjv+u+MGu9k23fPbDJN5FmUpTK531Ks3BAjbUwBCoEQfIFrLm5hPTd6chKmcMH6ilxHJ11aQHrMcFkGpr5z/1lnRQGiuCqnoe5dAigu0IWIQOqdinPrYlFx74zHqVijPgPICYYX6XMRhmEOnND1s1CiBqxW/rqvWCuUqIyRb1Gl/Mm2cEyRFP53e0A/bTLia57M39Shp26lracttqmnTUqlpHVpa6INjpVRcHySlFcH8WhXaVlIarPHToTpc+F4nIrJiPv2JrO9cPMSs169/nbXQapBTS5JT4A8ppyLgqPq1f1zd/nOLUoQhaTq1tD+NLtDhDu1Nf1s2tgfdMvBjB7Sq69Is3eeClArta1WfaVVuLTWYpdJg5jBeKKhz0zE6OqHyOHK4oc8JBcY7d0JVUQkwtOOhvcw5DZmbXN9f3E4/KwzbdRrg7ZK0tECnoNDG1qv6ak0b0AHdKA0nLKXE7DMzuHFQ3746DGlrns5y8iQHxKRyP6R4tBKIEvs1gTDbCkSFjbaCi4J2rB6VUGSCjorUlKJ5YLfTpJT/cFtptmQNVvsnXMJXwB4YL85Lbj82a+3pRTGDzrkFkbbQbdrNdsiVTLuhA7mWBxSm3RvItNuGBEnbuHQtY/cB3RDaGNd9eVyN+Sev9+CKhu48uqI2jv77DW0/gizNBlaRs+7PwHrvy8D2o6ZUeXChu07EwLpy4cPUo83G3mHj6tRmqmC2UCpUPtMaRoWe4spswjY0eviJzp2+xxD//VzoJUmn3d/RZ55hXJiGR69+m91UdFfxpjfkn5uDJhw8ZfDDdgkFGJH3pu77ToQPml/zmnVjzd6CMxap2NmHl6A3rzismAtcvuFYw1cVQoQIvELayG/66m8vuz2ovvJP1lXtVgnsIRdUAvqUXVUgJcPlAxmtU0GedELEkgbS6Iv6oAPUjkyqv1D77TWhqKwZt08oakYHkEslJ5cplCIvKfN3aPvjM4W+89pY7Ree4gTaEPA8Om3sa0wba4N4J1SNFdZ3b7SwN0Dfna69qMTqBMN0JfiuCNFNy+ORBIHR3uj8I5To5MQNW9HzXU3aaYDIokt52lPFGfoPXKkVgiMbT5llrYsYtjSQfPBB54GF3qsW03g5z8XjvI9x9qE7hixWAOPA400nXqzoxTtSRYCndhrAkooKluy3nJyPL7lppvu6pwGA4WuyogPgtoMVBUKtdMtjHHsyYA+3+zB+YqH9Gb/flyRmSMj78e8yUNxgajLO0Rpez9jfqP9azqAZ+lLD94cjfnSRbtlhqNE6iQVardgXP88RuDZz5NjQGIYxnY14xqsv+7+NKTrMYowCpgzoc6ptGSi1AF+ywUMWBYC5/5CAJsjN1hg+JEi8Y3XW2GMr5u6v+aI1bw8fVwo1x034+Ar0yMn+buhpJrU+oYi6/A2+5XZTFjIueQ02VXevWRvdy0QVGup46WP7HamK0tx+R7H98vndbttv9260aOC/QDj3fs5XfMsMwADiq0gm9ie+zdNHujNHWUpD/rzf+cKndJkHgE/5MxxD4Md6harukFG0pchFn2qlTKRuXi2lYh0UQWkucE0ms4+yluYvK4Mh45BOmeiTUCX/rhdLMc0oR0pL5aIqw1valUt7Dmj6WQcNxx6MS8dx6zzx3R8wJb+7QzimK2cyeYiaV3BisJKjLZ0/B/2dwioXOkiylE4MhpDAc/T4Bjvw3qeSpre7X2Er4Lb7pTtw/R0=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="481px" viewBox="-0.5 -0.5 831 481" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VzdcqM2FH4az7QXyQAyGC4dO0k73Z1mmk67e9VRbAXTxcgVcmL36VcCCYOQsxgL4sRxZnbhIAlJ5zv/sgdgstzcErhafMZzFA8ca74ZgOnAcfxRwP7lhG1OcD0nJ4Qkmucke0e4j/5HgmgJ6jqao7TSkGIc02hVJc5wkqAZrdAgIfhZNBPDPeK4+tYVDFGNcD+DcZ36dzSnC7Es19rRf0FRuJBvti3x5AHOvoUErxPxvoEDHrNP/ngJ5ViifbqAc/xcIoHrAZgQjGl+tdxMUMy3Vm5b3u9mz9Ni3gQltFEHyaknGK/F4qckekJ81yKyfGYjiZnSrdydbH2Ij2ANwNXzIqLofgVn/OkzgwOjLegyZnc2u3yM4niCY0yyvuBmzP8YPaUEf0OlJ1b2YU9gHIUJo8Xoka3h6gkRGjHWjAWZYv6GlL0wSsJPWZvpiFHqSxe7wQdAmxJJbMUtwktEyZY12VTht63ePu8gUNAWJfYPPUGEAnZhMfJu69mF2H09J5yhVeNEbedL+4o2Ef0iWMCvv/LrS1fcTTelR9OtvEnYpL7IAfhNqRe/3XXL7mS/KsP3bnSK12QmZup4npBbSEIk2jnBMCeieUX+6gwhKIaUw7Ai2ZrtFV3vcMQmUzByOHKrnLQVDuVTFb3K8vGDgXxlnHx1tXEyZhfLacb/0bDGbr5N9+IWE7rAIU5gfL2jXr0hQLi+BhASJeYA0Vje5Hwq8ubFXOXMoyd2GdJsbTnpEWewmBX6yvtvjfMGUnOVSHnfuxgyXKANlYOwOeXjVMdm5Mobj1G3UnnOGC8Q0ajPZTSfZ9ApTA8fNYxhmorrqmotUa4wpXhZpf3JtXFGUBT9ZHLDPnwzYbrIZm+bUdKuV9XSzqiupm1Hp6ZNaGmpD46VUnl9kJSWBPNrWWgbSelsTZ4O1eHS9zoRkZXz6U5kA+/iIeK9fv3rrIXWgJw6ipyCoE85lQFH2a/94+r2n1uUIAJp3all/Vl0gQ53aG+627Kh2+uWgR87oGVdl+BknwtSKLSvZX1mVLk11GCOToPZ/XihoMpNz2rphKrjqOGGOScUWO/cCdVFJcAyjofmMufVZG58fX9xO/msMWzXyYxsV7ShBToFhTZ0XtVXq9uAFuhGyXzMU0rcPnODG82q21eFIWst0lleluSAhJbu+xSPRgJRYL8iEHZTgSix0dVwUdKO1aMKimzQUpHaSjQP3GaalPEfbkvNVrxBun/CBXwl7IH14rzU9kO70p5d5DNonVuQaQvTpt1uhlzFtFsmkOv4QGPa/Z5Mu2spkHSty5Fj7T6gHUJr445eHtdg/snvPLhiobuIrpiNY/9+Q9uPIMuwgdXkrLszsP77MrDdqCldHlzqrhMxsCO18GGb0WZD/7BxTWozXTCbKxUmn0kFo1JPCWU25hsaPvzE5s7eY8n/fs71kqLT7u/YM9+yLmzLZ1e/TW9Kuit/0xvyz+1eEw6+Nvjhu4RmBNH3pu67ToT3ml/z63Vjw96CNxTOQgrj866gGMCKmlnsV9AlMt9wtBHoSiFSCF4hcRTUvfW3l9/uVWMFJ+ustqsFdpANKgB9ys4qUNLh6pGMxskgXzkj4igDGfRGA9ACakem1V+o/naaUtRWjZunFA2jA6jFkpPLFSqxl5L7O7T98bnCwHttrHYLT3kGrQ94Hp04Dgwmjo1BvBWqhhrruzde2Bui787XXpSidUpgkkq+a4J02/FFLEFhuDc+/wglWjlx/db0gpEh7dRDZNGmQO3r4gzzR670CsFTjafKssZlDFcZSD36YPLIQud1i0m0WmTi8ZGGMK07+ixXAOvAA04nXq7oxDvSRYCndh7AUcoKjuq3nJyPr7hp9uh1zwMAKzBkRXvAbQsrCqRaaZfHOPZswB5ud2H85EK7M35ZRcuK4QP/ht/5Wb/rKf8bdF+96TUjX2j07nAjDiuyLTsMNUYnsURpyr/qeY7AdbnjxocmcB6x2chnotqy//uXssM0ImhGI8xnzbQrB6UR4Cs2t88iALD3HwswBLnpmsCHGMl3pGeNPb5i4e7aL1rv5vAZKaHlsA6fQIMeNbnfDj31JNYnFDIXv8a3LFhUhUxIXo1N5d2r10L3MlGHhipeuth+T6ma1Lff02y/emK33fa7nRstFugvEYHxWYtvEfH3IL6a5GF34ls/b2Q6U4QTFuJn/c4XPoXL3AN8ih/e6AM/zitUcfuMmh1N7vlUK2MyVfNqKRTnoAjKcEFrPJ5+lLEMfz0Z9BmHtMo8n4Qq+Xe9XMlphhlSGioXXdndMa5cmnPA0A85GDjmYF163qjKk2D0A6Zkd3eIRGzlXCYPUfMaTvRWYnSVE+egu1NXxUK78/d+X/H8SBYusInBOaTwHD2+3o64d6mk2e3ud9dyuO1+2w5cfwc=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -231,7 +231,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            64-bit ID
+                                            64-bit salt
                                         </font>
                                     </div>
                                 </div>
@@ -239,7 +239,7 @@
                         </div>
                     </foreignObject>
                     <text x="310" y="164" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        64-bit ID
+                        64-bit salt
                     </text>
                 </switch>
             </g>
@@ -355,7 +355,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            Optional context string
+                                            KDF label
                                         </font>
                                     </div>
                                 </div>
@@ -363,7 +363,7 @@
                         </div>
                     </foreignObject>
                     <text x="610" y="164" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Optional context str...
+                        KDF label
                     </text>
                 </switch>
             </g>

--- a/doc/ocp_lock/diagrams/preconditioned_key_extract.drawio.svg
+++ b/doc/ocp_lock/diagrams/preconditioned_key_extract.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="501px" viewBox="-0.5 -0.5 831 501" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VtbU9s4FP41maEPMLJFbo/kQtuhnWUGZnb7KGxha7GtrCxDsr9+JVuyrVghIcRxWJp2QDqWdI6OzncuiunBabz8ytAi/El9HPVc4C97cNZz3dFwLH5Kwqog9AduQQgY8QuSUxHuyL9YEYGiZsTHqTGQUxpxsjCJHk0S7HGDhhijL+awRxqZXBcowA3CnYeiJvVP4vNQbasPKvo3TIJQc3aAevKAvKeA0SxR/HoufMw/xeMY6bXU+DREPn2pkeC8B6eMUl604uUUR1K1Wm3FvOsNT0u5GU74LhPKKc8oyrCWOZeMr7Q28v1gOQP04OQlJBzfLZAnn76I4xe0kMeR6DmiiSISJKLtCQkwE4RnzDgRqr1SD2Li+3LlSbl3uWoQoTRV7VQsTpLgB37kJmVCOaexSbunC0V4JFE0pRFludTwOv9IOk24MjEnn8gZfcK2kU3tae2IPeBljaS0+RXTGHO2EkPU06G2EWX5Q9V9qcxorEhhzYK0PSBluEG5cHV4oqHOz36WEDSPDvvCrlU3oQk2zwovCf9Lau+ir3q/ak9mS6XYvLPSnUSIVZsku7/qz6ppeU/P26jblGbMU+K644FCO2IB1roZK28iN/PqGTAcIU6eTRC/R6WlPAY8BpGQbOKTZ9EMeL63giQtLfdK2rQG/2S0GABB/qmTirnfk0UmJ6VILKHWEWIVS5nLC7LB9H8B0+lUgc9HaZhL7xwGiS7oG0h0mkh0XAsULw8CxcGeUHRqQKxguQ2KBhArXL4PisMmFKHWaRdQHDageDW/O59PJ1KexGOrBW8qPYpEzoC342FT8GjDEMdHtcTLjx8URragMOzOEkdtB4W7PBgAL8TeU5rFovmEV586OrSBQ3hUHMKPj8OxDYej7nA4buDwnmWJhzgWVGFCTVAukJ/XkuKHKEplwUZ4uiOCTjGWWMqLFk3YaepkDxMGe5mwcwgThrpOP5FQUsrTXii5jRARTnwp2ldiLljKYRcXF58xmsxn8l87SHT7R4Xi6ONDsd+EIgQdQrHfNhQdd3Qu4o2R2L0JhAeV5uxmdi3aKJZoTR7ShcnYJo/AV2IYnV6zuvY8VzJIX8MZSlJtBpOmBB7NHdOXGteCwydwRYdMbOGgywLTGe7pik7mqqP0OoYrctzuXFHzquPuVvRHAJw70vWDHLsnmJ82TPGoNZa+4vu4NRYElhqr06jYrLFaugD/7Dcch77/bkDxqEjsf/j8VPt/MyjAzpCo5WmxVGRYpGQ+4UQcj99tbmh6g99p4R4OoO92Gov3/QbshDwAtHmAy+48AHwlLYTQ4g1uJIrAfCnQ5vEdgXMKaeS66R71mlOfcHuO9o+M75vzHFSOGAlvR1D0O+86YN7VcLtHtd3X7wUp4yENaIKieUXtqjb/O4sXWrAgtxPTknZy0tY3hlpI0/KpV4yhVW3AgpJEfn1UrnwrCbUU/NI0Bbj2Mt6W4WOwdvYF/8oSyo3saBzNWs6MH2AtXoB8ELg/+/bzanoeCqCcFa8pTeXYMvPLHqyJn+UCtJ7SyVnao4DecCr/u8U3E1V3DybJdiazY4i+B5PYzuRLofCnHzgp70oPFAH03Admcfq2WPB6MPouSwAekjSXI0k5yzxZTeQ5/xsDWhatUyKiKaU9SvOWzCSh77g1JtXg5vSWapaty9bWYsHDGSjOVf/6Yl30prYnWxm0ybrWeA1gwaX6bWe30c5b2FqjwtzmBI6jgo0O5G0q2JXduhZIunm7xkAeytcciPX6bEPB/C5Q7HPEs12O7nQt7w3ib/DdttMFxcnheMFX+ZaYSFRfPSVBbLpDuyfdjbqWIxbvB6y9Ga9KdJ2xR3m+baTRzSJ+PZvnMv221gRmrld/R98tJXxXHq7zbp17Wb6f748sebgzeHsiLrrV32wUqVn1dzFw/h8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="831px" height="501px" viewBox="-0.5 -0.5 831 501" content="&lt;mxfile&gt;&lt;diagram id=&quot;l2TypUd-224jlg0m0S9I&quot; name=&quot;Page-1&quot;&gt;7VtbT+M4FP41lZgHkBPT2yO0ZWbEjBYJpNl5NIlJvCRx13Gg3V+/dmInceJeKE1bli0I7BNfju3znVvcHpzEi68MzcOf1MdRzwX+ogenPdcdDcfiryQsC0J/4BaEgBG/IDkV4Z78gxURKGpGfJwaDTmlESdzk+jRJMEeN2iIMfpqNnuikTnrHAW4Rbj3UNSm/iI+D9Wy+qCif8MkCPXMDlBPHpH3HDCaJWq+nguf8k/xOEZ6LNU+DZFPX2skOOvBCaOUF6V4McGR3Fq9bUW/mxVPS74ZTvg2HcouLyjKsOY554wv9W7k68GyB+jB69eQcHw/R558+iqOX9BCHkei5ogiikiQiLInOMBMEF4w40Rs7ZV6EBPflyNfl2uXowYRSlNVTsXgJAl+4CduUq4p5zQ2aQ90rghPJIomNKIs5xre5B9JpwlXIubkHTmjz9jWsr17enfEGvCiRlK7+RXTGHO2FE3U06GWESX5Q1V9rcRorEhhTYK0PCAluEE5cHV4oqDOz36WELSPDvtCrlU1oQk2zwovCP9T7t5FX9V+155MF2pj88pSVxLBVq2TrP6uP6u65TXdb+XepjRjnmLXHQ8U2hELsN6bsdImcjFrz4DhCHHyYoL4PVta8mPAYxAJzq598iKKAc/XVpCkpOVaSYvW4O+MFg0gyD91UtH3ezLPZKcUiSHUOIKtYihzeEE2Jv1PwHQyUeDzURrm3Dv7QaLTQKLTRqLjWqB4uRcoDnaEolMDYgXLTVA0gFjh8n1QHLahCEH/eFActqB4Nbs/n02uJT+Jx5Zz3t70KBI+A96Mh1XGowtBHB9UEi8/vlEY2YzC8HiSOOraKNznxgB4Ifae0ywWxWe8/NTWoQscwoPiEH58HI5tOBwdD4fjFg4fWJZ4iGNBFSLUBuUc+XksKf6IoFQGbISnWyLoFG2JJbzoUISd9p7sIMJgJxF29iHCUMfpJ2JKSn66MyV3ESJCiS9E+Ur0BQvZ7OLi4jNak9lU/nSDRLd/UCiOPj4U+20oQnBEKPa7hqLjjs6FvTEcuzeBcK/cnN1Ob0QZxRKtyWM6Nye28SPwlRhCp8es0p7nigepazhDSarF4LrNgUdzxfSlNmsxwydQRft0bKFzzADTGe6oik4m1VFqHUMVOe7xVFE71XF/J+ojAM4dqfpBjt0T9E9bonjQGEtP/nFjLAgsMdZRrWI7xuooAf7ZMxz7zn+3oHhQJPY/vH+q9b9pFODRkKj56TBUZFi4ZD7hRByPf1zf0NQG/7uFOyiAy+ExbbG7PllEGQ9pQBMUzSrq/rzEtykEU1a2VA/Qoh70bh5DPcA1PiOEFlVxKyEGZgsBRY9viapT8DGbcn3QHKi7Po2/tViDPYj1Jo9zJ7G+PIj/mXe9Ygwtaw3mlCQyG1+OfCcJtYNvpNxg427ThubD9c2hXawqwSjYrcSkXPeWAL3s2n7nQSGI0KO8jPf5POnZQP504Em3DOlBPen1md6O7aihbjZmW/7K4rlmLMjlZAcVZL0D1oHjvZMKKi/vbaeCms3H+9Yp7ejcNPqgYeRB3gg8nH37eTU5DwVQzoqLZxPZtvTls0erK29JadeddNlLaxTQG07kr1u8a6qqO0ySbJ5kegjWd5gktk/ypdjw5x84KbPfezICuu8jsyh9my1Y/4bhuwzqeEjSnI8k5SzzZHyYR3FvfEuRRU1KRDSllEcp3nIySeg7bm2SqnG7e0dR6MZha2Ox4PEMFOeq/32xDnrbWx/YrpKuxlwDWMxS/bdPt1LOO1haK2ewSQkcZgtWKpC3bcG20zV3gaSrl2s05KG8uEKsCdEVKZB3gWKXI55uc3SnK3lvYH+F7radLihODsdzvsyXxISjuvaUBLGtDu2adDtqw0csbnw0vuug0q7aY49yf9two9uJ2aY3z6X7bY0JTF+v/q0Lt+TwfVcuGr6X5cZFf2Txw53BXiL/zq/q/JHxXV+F7JWPGIlAjqBPGUR29jpmAA8WRIpq9Q2yIqyovqUHZ/8C&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
     <g>
@@ -6,17 +6,17 @@
             <rect x="740" y="60" width="90" height="20" fill="#ffffff" stroke="#ffffff" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
         </g>
         <g>
-            <path d="M 255 40 L 255 53.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 255 58.88 L 251.5 51.88 L 255 53.63 L 258.5 51.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 40 L 200 53.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 58.88 L 196.5 51.88 L 200 53.63 L 203.5 51.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="195" y="0" width="120" height="40" fill="#ccffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="140" y="0" width="120" height="40" fill="#ccffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 196px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 141px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -28,24 +28,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="255" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="200" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Input salt
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 315 200 L 348.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 353.88 200 L 346.88 203.5 L 348.63 200 L 346.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 260 200 L 293.63 200" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 298.88 200 L 291.88 203.5 L 293.63 200 L 291.88 196.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="255" cy="200" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="200" cy="200" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 196px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 141px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     AES-ECB encrypt
@@ -53,24 +53,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="255" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="200" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         AES-ECB encrypt
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 255 160 L 255 173.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 255 178.88 L 251.5 171.88 L 255 173.63 L 258.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 160 L 200 173.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 178.88 L 196.5 171.88 L 200 173.63 L 203.5 171.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="195" y="120" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="140" y="120" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 196px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 141px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -82,24 +82,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="255" y="144" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="200" y="144" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Salt checksum key
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 255 100 L 255 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 255 118.88 L 251.5 111.88 L 255 113.63 L 258.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 100 L 200 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 118.88 L 196.5 111.88 L 200 113.63 L 203.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="255" cy="80" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="200" cy="80" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 196px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 141px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     Truncate or
@@ -110,24 +110,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="255" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="200" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Truncate or...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 255 240 L 255 226.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 255 221.12 L 258.5 228.12 L 255 226.37 L 251.5 228.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 240 L 200 226.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 200 221.12 L 203.5 228.12 L 200 226.37 L 196.5 228.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="195" y="240" width="120" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="140" y="240" width="120" height="40" fill="#ededed" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(237, 237, 237), rgb(33, 33, 33)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 196px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 141px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -139,24 +139,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="255" y="264" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="200" y="264" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Plaintext: 0x0000...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 415 180 L 415 166.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 415 161.12 L 418.5 168.12 L 415 166.37 L 411.5 168.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 360 180 L 360 166.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 360 161.12 L 363.5 168.12 L 360 166.37 L 356.5 168.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="355" y="180" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="300" y="180" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 356px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 301px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -176,24 +176,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="415" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="360" y="204" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         128-bit checksum...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 475 140 L 508.63 140" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 513.88 140 L 506.88 143.5 L 508.63 140 L 506.88 136.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 420 140 L 453.63 140" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 458.88 140 L 451.88 143.5 L 453.63 140 L 451.88 136.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="415" cy="140" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="360" cy="140" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 356px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 301px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     SP 800-108 KDF
@@ -201,24 +201,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="415" y="144" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="360" y="144" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         SP 800-108 KDF
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 415 40 L 415 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 415 118.88 L 411.5 111.88 L 415 113.63 L 418.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 360 40 L 360 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 360 118.88 L 356.5 111.88 L 360 113.63 L 363.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="355" y="0" width="120" height="40" fill="#ccffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="300" y="0" width="120" height="40" fill="#ccffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 356px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 301px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -230,24 +230,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="415" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="360" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Input key
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 575 120 L 575 106.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 575 101.12 L 578.5 108.12 L 575 106.37 L 571.5 108.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 520 120 L 520 106.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 520 101.12 L 523.5 108.12 L 520 106.37 L 516.5 108.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <rect x="515" y="120" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="460" y="120" width="120" height="40" fill="#ccffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 516px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 461px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
@@ -262,24 +262,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="575" y="144" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="520" y="144" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Preconditioned key
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 575 60 L 575 46.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 575 41.12 L 578.5 48.12 L 575 46.37 L 571.5 48.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 580 80 L 680 80 L 680 46.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 680 41.12 L 683.5 48.12 L 680 46.37 L 676.5 48.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
-            <ellipse cx="575" cy="80" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <ellipse cx="520" cy="80" rx="60" ry="20" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 516px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 461px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     SP 800-133
@@ -290,45 +290,44 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="575" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="520" y="84" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         SP 800-133...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="515" y="0" width="120" height="40" fill="#ccffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 460 20 L 440 20 L 440 60 L 360 60 L 360 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 360 118.88 L 356.5 111.88 L 360 113.63 L 363.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="460" y="0" width="120" height="40" fill="#e6e6e6" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(230, 230, 230), rgb(39, 39, 39)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 516px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 461px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            Output key
-                                        </font>
-                                    </div>
-                                    <div>
-                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            material
+                                            KDF label
                                         </font>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="575" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Output key...
+                    <text x="520" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        KDF label
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 315 20 L 335 20 L 335 80 L 412 80 M 418 80 M 418 80 L 508.63 80" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 513.88 80 L 506.88 83.5 L 508.63 80 L 506.88 76.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 260 20 L 280 20 L 280 80 L 357 80 M 363 80 M 363 80 L 453.63 80" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 458.88 80 L 451.88 83.5 L 453.63 80 L 451.88 76.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <rect x="0" y="340" width="580" height="160" fill="none" stroke="none" pointer-events="all"/>
@@ -415,6 +414,36 @@
                     </foreignObject>
                     <text x="2" y="359" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         SP 800-133 Key Extract = T(HMAC-hash(salt, K1 || ... || Kn || D1 || ... || Dm), kLen)...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="620" y="0" width="120" height="40" fill="#ccffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(rgb(204, 255, 255), rgb(0, 37, 37)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 621px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    <div>
+                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                            Output key
+                                        </font>
+                                    </div>
+                                    <div>
+                                        <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
+                                            material
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="680" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Output key...
                     </text>
                 </switch>
             </g>

--- a/doc/ocp_lock/diagrams/uml/get_algorithms.uml
+++ b/doc/ocp_lock/diagrams/uml/get_algorithms.uml
@@ -10,21 +10,6 @@ dfw -> cfw++ : GET_ALGORITHMS
 
 cfw -> cfw: Fill the set of algorithms supported
 
-note over cfw
-    The Algorithms to support
-
-    From the HPKE base spec:
-
-    * kem_id = 0x0011: P-384
-    * aead_id = 0x0002: AES-256-GCM
-    * kdf_id = 0x0002: HKDF-SHA384
-
-    For post-quantum crypto, from [[https://datatracker.ietf.org/doc/draft-irtf-cfrg-hybrid-kems/ Hybrid PQ/T Key Encapsulation Mechanisms]]:
-
-    * kem_id = 0x0a25: ML-KEM-1024 + P-384
-    * aead_id and kdf_id will be the same as from the base spec.
-end note
-
 cfw -> dfw : Command\nResponse\nSet of algorithms supported
 cfw--
 

--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -2,7 +2,7 @@
 title: "OCP L.O.C.K."
 version: 0.8.5
 type: BASE
-project: NVMe^TM^
+project: NVMe™
 authors: [(See Acknowledgements section)]
 bibliography: bibliography.yaml
 ...
@@ -117,7 +117,9 @@ OCP L.O.C.K. (Layered Open-source Cryptographic Key management) is a feature set
 
 OCP L.O.C.K. was originally created as part of the Open Compute Project (OCP). The major revisions of the OCP L.O.C.K. specifications are published as part of Caliptra at OCP, as OCP L.O.C.K. is an extension to Caliptra. The evolving source code and documentation for Caliptra are in the repository within the CHIPS Alliance Project, a Series of LF Projects, LLC.
 
-OCP L.O.C.K. may be integrated within a variety of self-encrypting storage devices, and is not restricted exclusively to NVMe^TM^.
+OCP L.O.C.K. may be integrated within a variety of self-encrypting storage devices, and is not restricted exclusively to NVMe™. OCP L.O.C.K. is designed for compatibility with the TCG Opal[^opal] [@{tcg-opal}] or Key Per I/O [@{tcg-kpio}] storage device specifications.
+
+[^opal]: Opal in the context of this document includes the Opal Family of SSCs: Opal SSC, Opalite SSC, Ruby SSC. Pyrite is excluded as Pyrite SSDs are non-SED.
 
 ## Background
 
@@ -129,7 +131,7 @@ Self-encrypting drives (SEDs) store data encrypted at rest to media encryption k
 - An encryption engine which performs line-rate encryption and decryption of data as it enters and exits the drive.
 - A drive controller which exposes host-side APIs for managing the lifecycle of MEKs.
 
-MEKs may be bound to user credentials, which the host must provide to the drive in order for the associated data to be readable. A given MEK may be bound to one or more credentials. This model is captured in the TCG Opal [@{tcg-opal}] specification.
+MEKs may be bound to user credentials, which the host must provide to the drive in order for the associated data to be readable. A given MEK may be bound to one or more credentials. This model is captured in the TCG Opal specification.
 
 MEKs may be erased, to cryptographically erase all data which was encrypted to the MEK. To erase an MEK, it is sufficient for the drive to erase all copies of it, or all copies of a key with which it was protected.
 
@@ -167,9 +169,6 @@ The OCP L.O.C.K. KMB satisfies the following properties:
 - Prevents leakage of media keys via firmware vulnerabilities or side channels, by isolating MEKs to a trusted component.
 - Binds MEKs to a given set of externally-supplied access keys, provisioned with replay-resistant transport security such that they can be injected without trusting the host.
 - Uses epoch keys for attestable epoch-based cryptographic erase.
-- Is able to be used in conjunction with the Opal or Key Per I/O [@{tcg-kpio}] storage device specifications.
-
-Note that Opal in the context of this document includes the Opal Family of SSCs: Opal SSC, Opalite SSC, Ruby SSC. Pyrite is excluded as Pyrite SSDs are non-SED.
 
 ### Non-goals
 
@@ -263,15 +262,15 @@ Table: Critical Security Parameters {#tbl:critical-security-parameters}
 |                   | See @fig:mpk-generation for one of   |                                                             |               |
 |                   | several flows where this is done.    | Rendered irrecoverable if the SEK, HEK seed, or DICE UDS    |               |
 |                   |                                      | are zeroized.                                               |               |
-|                   | Contributes to the derivation of an  |                                                             |               |
-|                   | MEK secret. See                      |                                                             |               |
+|                   | Contributes to the derivation of     |                                                             |               |
+|                   | each MEK secret. See                 |                                                             |               |
 |                   | @fig:mek-secret-derivation.          |                                                             |               |
 +-------------------+--------------------------------------+-------------------------------------------------------------+---------------+
 | HPKE private key  | Provides transport encryption for    | Randomly generated on startup. Held in volatile memory,     | No            |
 | seed              | injected access keys. See            | rotated on demand, and lost on cold reset.                  |               |
 |                   | @sec:hpke-transport-encryption.      |                                                             |               |
 +-------------------+--------------------------------------+-------------------------------------------------------------+---------------+
-| Access keys       | Contributes to the derivation of a   | Managed outside of Caliptra. Asymmetrically encrypted       | Yes           |
+| Access keys       | Contributes to the derivation of a   | Managed outside of Caliptra. Asymmetrically encrypted       | Yes[^ak_kv]   |
 |                   | Locked MPK encryption secret. See    | using the HPKE public key. When held by Caliptra, each      |               |
 |                   | @fig:mpk-generation for one of       | access key is held in the Key Vault and is zeroized after   |               |
 |                   | several flows where this is done.    | each use.                                                   |               |
@@ -314,7 +313,7 @@ Table: Critical Security Parameters {#tbl:critical-security-parameters}
 |                   |                                      | are zeroized.                                               |               |
 +-------------------+--------------------------------------+-------------------------------------------------------------+---------------+
 
-Note: the access key is generally held in the Key Vault when it is decrypted within Caliptra. The one exception to this is during access key testing, when the decrypted access key is hashed along with other data. Since the Key Vault hardware does not presently support hashing keys, during this flow the decrypted access key is held in Caliptra's main memory. See @sec:mpk-access-key-testing for more details.
+[^ak_kv]: Access keys are generally held in the Key Vault when they are decrypted within Caliptra. The one exception to this is during access key testing, when the decrypted access key is hashed along with other data. Since the Key Vault hardware does not presently support hashing keys, during this flow the decrypted access key is held in Caliptra's main memory. See @sec:mpk-access-key-testing for more details.
 
 #### Key Vault
 
@@ -340,17 +339,26 @@ The input key is preconditioned using a unique identifier derived from the salt,
 
 Subsequent diagrams will use this operation when combining keys with different scopes or lifetimes.
 
+The design of this operation is informed by a number of constraints on Caliptra hardware. Keys in the Key Vault support the following symmetric cryptographic operations:
+
+  - Use as an AES key or message
+  - Use as an HMAC key or message
+
+Notably, if a key in the Key Vault is used as an HMAC message, it constitutes the entirety of the HMAC message. No concatenation with other data is possible. Therefore a key in the Key Vault cannot be used as e.g. an SP 800-108 KDF's context string, which must be concatenated with other values such as the block counter.
+
+The AES engine is used to compute the salt checksum because that is the only supported path for extracting an identifier from a key in Key Vault.
+
 #### Preconditioned AES {#sec:preconditioned-aes}
 
 In this specification, several flows involve deriving a key for use in AES-GCM. In AES-GCM it is critical that IV collisions be avoided. To that end SP 800-38D [@{sp800-38d}] section 8.3 stipulates that AES-GCM-Encrypt may only be invoked at most $2^{32}$ times with a given AES key. One approach to address this constraint is to maintain counters to track the usage count of a given key. Such tracking would be difficult for Caliptra, which lacks direct access to rewritable storage which would be needed to maintain a counter that preserves its value across power cycles.
 
-To elide the need for maintaining counters, this specification defines the "preconditioned AES-Encrypt" and "preconditioned AES-Decrypt" operations, illustrated in @fig:preconditioned-aes-encrypt and @fig:preconditioned-aes-decrypt.
+To elide the need for maintaining counters, this specification defines the "preconditioned AES-Encrypt" and "preconditioned AES-Decrypt" operations, illustrated in Figures [-@fig:preconditioned-aes-encrypt] and [-@fig:preconditioned-aes-decrypt].
 
 ![Preconditioned AES-Encrypt](./diagrams/preconditioned_aes_encrypt.drawio.svg){#fig:preconditioned-aes-encrypt}
 
 ![Preconditioned AES-Decrypt](./diagrams/preconditioned_aes_decrypt.drawio.svg){#fig:preconditioned-aes-decrypt}
 
-Each AES secret is preconditioned using a randomly-generated 64-bit identifier, before being used with AES-GCM-Encrypt. This ensures that it is safe to use a given input AES secret in approximately $2^{64}$ preconditioned AES-Encrypt operations before an IV collision is expected to occur with probability greater than $2^{-32}$. $2^{64}$ is large enough that a given storage device will experience hardware failure well before that limit is reached. Ergo, usage counters within the drive are not needed for these keys. See [Appendix @sec:preconditioned-aes-calculations] for additional details on the calculations behind this figure.
+Each AES secret is preconditioned using a randomly-generated 64-bit salt, before being used with AES-GCM-Encrypt. This ensures that it is safe to use a given input AES secret in approximately $2^{64}$ preconditioned AES-Encrypt operations before an IV collision is expected to occur with probability greater than $2^{-32}$. The $2^{64}$ limit is large enough that a given storage device will experience hardware failure well before that limit is reached. Ergo, usage counters within the drive are not needed for these keys. See [Appendix @sec:preconditioned-aes-calculations] for additional details on the calculations behind this figure.
 
 In addition to a plaintext message, this operation supports optional metadata for the message, which is attached as AAD.
 
@@ -597,7 +605,7 @@ See @sec:generate-load-random-mek for how the MEK secret is used to generate and
 
 #### Generating and loading a random MEK {#sec:generate-load-random-mek}
 
-@fig:mek-generate and @fig:mek-load elide the process of deriving the MEK secret, as those details are captured in @fig:mek-secret-derivation. When an MEK is generated or loaded, the inputs given in @fig:mek-secret-derivation are provided by drive firmware so that KMB may derive the MEK secret.
+Figures [-@fig:mek-generate] and [-@fig:mek-load] elide the process of deriving the MEK secret, as those details are captured in @fig:mek-secret-derivation. When an MEK is generated or loaded, the inputs given in @fig:mek-secret-derivation are provided by drive firmware so that KMB may derive the MEK secret.
 
 ![Generating an MEK](./diagrams/mek_generate.drawio.svg){#fig:mek-generate}
 


### PR DESCRIPTION
- Preconditioned AES: s/optional context string/KDF label/
- Preconditioned AES: s/random ID/random salt/
- Preconditioned key-extract: add KDF label input
- Preconditioned key-extract: add justification for the design of the operation.
- GET_ALGORITHMS UML: removed inline algorithm IDs, as they were out of date and redundant.
- Use trademark symbol.
- Use footnotes instead of "Note" clauses.
- "Figures x, y, and z" instead of "Figure x and Figure y and Figure z"

Fun fact: a footnote anchor can appear in a table cell. However, that footnote cannot be the first footnote in the document. It must be preceded by another one. But: that first footnote's anchor cannot be in a bulleted list; it must be in a regular paragraph. I regret knowing this.