### PR TITLE
Correct links to version 1.x HW spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ sets out the charter governing the Caliptra project.
 
 ### Caliptra 1.x:
   * [Main Caliptra specification 1.x](https://github.com/chipsalliance/Caliptra/blob/main/doc/caliptra_1x/Caliptra.md)
-  * [Caliptra Core Hardware Specification](https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraHardwareSpecification.md)
+  * [Caliptra Core Hardware Specification](https://github.com/chipsalliance/caliptra-rtl/blob/v1.1/docs/CaliptraHardwareSpecification.md)
   * [Caliptra Core Hardware Integration
-    Specification](https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraIntegrationSpecification.md)
+    Specification](https://github.com/chipsalliance/caliptra-rtl/blob/v1.1/docs/CaliptraIntegrationSpecification.md)
   * [ROM 1.x](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md)
   * [FMC](https://github.com/chipsalliance/caliptra-sw/blob/main/fmc/README.md)
   * [Runtime](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md)


### PR DESCRIPTION
Readme links to the _Core Hardware Specification_ and _Core Hardware Integration Specification_ for version 1.x were still pointing to the RTL repos `main` branch which has moved forward and now points to v2.x development/specification.

These have been corrected to point to the `v1.1` tag.