### PR TITLE
Add an opaque AAD field for HPKE-wrapped access keys.

### DIFF
--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -2047,6 +2047,10 @@ Table: SealedAccessKey contents {#tbl:sealed-access-key-contents}
 |                |                       | value associated with a bit value indicated as |
 |                |                       | supported in @tbl:get-algorithms-output-args.  |
 +----------------+-----------------------+------------------------------------------------+
+| aad            | u32                   | AAD attached to the encapsulated access key.   |
+|                |                       | Opaque to KMB; may be interpreted by drive     |
+|                |                       | firmware.                                      |
++----------------+-----------------------+------------------------------------------------+
 | info_len       | u32                   | Length of the info field.                      |
 +----------------+-----------------------+------------------------------------------------+
 | info           | u8[info_len]          | Info to use with HPKE unwrap.                  |


### PR DESCRIPTION
This would allow TCG MEK-MPA to define a set of flags for this field, one of which could instruct drive firmware to atomically invoke ROTATE_HPKE_KEY for the target HPKE keypair once the access key has been unwrapped. This would provide anti-replay for remotely-provisioned access keys.