### PR TITLE
Move LOCK specs to after jekyll build.

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -45,10 +45,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Stage LOCK releases
-        run: |
-          mkdir -p gh-pages/ocp-lock/specification/
-          cp doc/ocp_lock/OCP_LOCK_Specification_*.pdf gh-pages/ocp-lock/specification/
       - name: Stage README
         run: |
           mkdir -p gh-pages-staging/doc
@@ -60,6 +56,10 @@ jobs:
         with:
           source: gh-pages-staging
           destination: gh-pages
+      - name: Stage LOCK releases
+        run: |
+          mkdir -p gh-pages/ocp-lock/specification/
+          cp doc/ocp_lock/OCP_LOCK_Specification_*.pdf gh-pages/ocp-lock/specification/
       - name: Upload artifacts for index
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
It appears that jekyll-build-pages is overwriting previously-staged content.