### PR TITLE
Allocate SFR interface error code for invalid command codes.

### DIFF
--- a/doc/ocp_lock/lock_spec.ocp
+++ b/doc/ocp_lock/lock_spec.ocp
@@ -1011,15 +1011,17 @@ Table: Offset OCP_LOCK_MEK_ADDRESS + 80h: CTRL – Control {#tbl:ee-ctrl-sfr}
 
 Table: CTRL error codes {#tbl:ee-ctrl-err-codes}
 
-+----------+--------------------+
-| Value    | Description        |
-+==========+====================+
-| 0h       | Command successful |
-+----------+--------------------+
-| 1h to 3h | Reserved           |
-+----------+--------------------+
-| 4h to Fh | Vendor Specific    |
-+----------+--------------------+
++----------+----------------------+
+| Value    | Description          |
++==========+======================+
+| 0h       | Command successful   |
++----------+----------------------+
+| 1h       | Invalid command code |
++----------+----------------------+
+| 2h to 3h | Reserved             |
++----------+----------------------+
+| 4h to Fh | Vendor Specific      |
++----------+----------------------+
 
 Table: CTRL command codes {#tbl:ee-ctrl-cmd-codes}
 


### PR DESCRIPTION
This will likely be a common code that vendors will elect to implement from their vendor-specific range.