### PR TITLE
Spec fixes: UDS, FE, image manifest

### DIFF
--- a/doc/caliptra_20/Caliptra.ocp
+++ b/doc/caliptra_20/Caliptra.ocp
@@ -664,7 +664,7 @@ There are two ways of generating a UDS seed:
 
 To use the internal TRNG to generate the UDS seed during manufacturing in subsystem mode:
 
-1. When SoC life cycle is in MANUFACTURING MODE, set the manufacturing service register bit SS_DBG_MANUF_SERVICE_REG_REQ[2] through JTAG to request the UDS seed programming flow.
+1. When SoC life cycle is in MANUFACTURING MODE, set the manufacturing service register bit [SS_DBG_MANUF_SERVICE_REG_REQ[2]](https://chipsalliance.github.io/caliptra-rtl/v2_0/internal-regs/?p=clp.soc_ifc_reg.SS_DBG_MANUF_SERVICE_REG_REQ#UDS_PROGRAM_REQ.desc) through JTAG to request the UDS seed programming flow.
 2. Caliptra ROM will sample this bit on power up; when this bit is set, Caliptra ROM rechecks that the life cycle state is manufacturing mode and reads the iTRNG for a 512-bit value.
 3. Caliptra ROM writes the 512-bit value to the address available through registers named SS_UDS_SEED_BASE_ADDR_L and SS_UDS_SEED_BASE_ADDR_H (which are strapped by SoC at integration time) by using Caliptra's DMA.
 4. Caliptra ROM sets the corresponding status bit in SS_DBG_MANUF_SERVICE_REG_RSP to indicate the flow completion.


### PR DESCRIPTION
Fix numerous bugs in the 2.0 spec:

* UDS is 512 bits, not 384
* FE is 4 64-bit fields, not 2 128-bit
* Correct the UDS provisioning flow
* Correct the image manifest to reflect the latest ROM
* Make notes about 32-bit dword endianness of SHA hashes in firmware manifest
* Formatting fixes