### PR TITLE
Revise Caliptra workgroup call invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,7 @@ and published security advisories, refer to
 
 The Caliptra workgroup meets every Thursday at 1pm PT. Meeting invite and agenda
 are posted to the [mailing list](https://lists.chipsalliance.org/g/caliptra-wg).
-The [call
-invite](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MmQwYTE4YzQtOWJkMy00YzcyLTgxMDUtYTQ2Zjk2ZjhkMzk5%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%22661ec88e-77cb-431c-935a-b377b1078af4%22%7d) is also reachable from the [CHIPS Workgroups
-page](https://www.chipsalliance.org/workgroups/).
+You can [join the call directly using this link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MmQwYTE4YzQtOWJkMy00YzcyLTgxMDUtYTQ2Zjk2ZjhkMzk5%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%22661ec88e-77cb-431c-935a-b377b1078af4%22%7d).
 
 A [Slack channel](https://join.slack.com/t/caliptraworkspace/signup)
 is used for interactive discussions. Keep in mind development activity is focused on


### PR DESCRIPTION
Instead of listing this meeting link on both the CHIPS website and here, we're now only including it in this documentation. This avoids having to update the link in multiple places if it changes.