### PR TITLE
[versioning] move compatability note

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,14 @@ Additional Features
   - IDevID CSR HMAC Signing
   - Crypto Offload Mailbox Services
 
+\*\*\* Only RTL release versions 2.0.2+ should be used due to ROM compatibility requirements.
+
 Compatible Configurations:
 
 | RTL | ROM | Runtime FMC/FW |
 | --- | --- | --- |
 | 2.0.2+ | 2.0.x | 2.0.x (0/0) |
 
-Note: only RTL release versions 2.0.2+ should be used due to ROM compatibility requirements.
 
 ## Test Dashboards
 


### PR DESCRIPTION
This moves the ROM compatability note for Caliptra 2.0 to before the markdown table. This change is required as the caliptra-web repo uses a tool (md2json.py) to parse the versioning information to generate the caliptra.io website. Without this change, there are parsing errors.