### PR TITLE
Change requirements from SHOULD to MUST for fuses access

### DIFF
--- a/CaliptraChecklistAndEvaluationMethodology.md
+++ b/CaliptraChecklistAndEvaluationMethodology.md
@@ -145,7 +145,7 @@ The following is a consolidated list of all requirements to ensure comprehensive
 #### *Access Control*
 
 * **Checklist Item:**  
-  * **Requirement:** Fuses containing Caliptra secrets MUST NOT be readable or writable by any mutable code in the SoC. Access MUST be restricted to secure hardware mechanisms and essential hardware functions like fuse sense and distribution logic.
+  * **Requirement:** Fuses containing Caliptra secrets MUST NOT be readable by any mutable code in the SoC. Access MUST be restricted to secure hardware mechanisms and essential hardware functions like fuse sense and distribution logic.
   * **Evaluation Methodology:** Manufacturers MUST provide hardware design documentation showing access controls on fuse read/write mechanisms, ensuring only authorized hardware components can access these fuses.
 
 #### *JTAG and Debug Interfaces*
@@ -157,8 +157,8 @@ The following is a consolidated list of all requirements to ensure comprehensive
 #### *Integrity Maintenance*
 
 * **Checklist Item:**  
-  * **Requirement:** The integrity of each fuse MUST be maintained throughout the lifespan of the device to prevent degradation or tampering that could affect security.  
-  * **Evaluation Methodology:** Manufacturers MUST describe the techniques used to ensure fuse integrity, such as redundancy, error correction codes (ECC), or other protective measures.
+  * **Requirement:** The integrity of each fuse SHOULD be maintained throughout the lifespan of the device to prevent degradation or tampering that could affect security.  
+  * **Evaluation Methodology:** Manufacturers SHOULD describe the techniques used to ensure fuse integrity, such as redundancy, error correction codes (ECC), or other protective measures.
 
 #### *In-Field Programmable Fuses*
 


### PR DESCRIPTION
This pull request updates the requirements and evaluation methodologies in the `CaliptraChecklistAndEvaluationMethodology.md` to strengthen language from recommendations ("SHOULD") to mandatory requirements ("MUST"). This clarifies that these security controls are not optional and must be strictly enforced by manufacturers.

Strengthening security requirements:

* Updated fuse access requirements to state that access to fuses containing UDS seed and field entropy MUST be restricted to authorized hardware mechanisms only, and manufacturers MUST provide supporting architectural diagrams and RTL code.
* Changed access control requirements for Caliptra secrets to indicate that fuses MUST NOT be readable or writable by mutable code in the SoC, and manufacturers MUST provide hardware design documentation showing access controls.
* Revised debug interface requirements so that JTAG and other debug interfaces MUST NOT allow access to sensitive fuses, and manufacturers MUST explain how unauthorized access is prevented.
* Updated fuse integrity requirements to specify that fuse integrity MUST be maintained throughout the device lifespan, and manufacturers MUST describe protective techniques used.