### PR TITLE
Add Caliptra Trademark delegates to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
-CaliptraChecklistAndEvaluationMethodology.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
-CaliptraTrademarkAuditProcess.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
-CaliptraTrademarkPolicy.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
+CaliptraChecklistAndEvaluationMethodology.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou @ericeilertson @JohnTraverAmd @syncsrc-nv @zhalvorsen
+CaliptraTrademarkAuditProcess.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou @ericeilertson @JohnTraverAmd @syncsrc-nv @zhalvorsen
+CaliptraTrademarkPolicy.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou @ericeilertson @JohnTraverAmd @syncsrc-nv @zhalvorsen
 CaliptraWGTechnicalCharter.md @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
 CODEOWNERS @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou
 LICENSE @andreslagarcavilla @Bryankel @Jhprabhu @nvpachou


### PR DESCRIPTION
This allows delegates from the TAC members to approve changes to the Caliptra trademark requirements.